### PR TITLE
Setting USER variable in jupyter/oauth-proxy container

### DIFF
--- a/k8s-templates/jupyter-notebook/deployment.yml
+++ b/k8s-templates/jupyter-notebook/deployment.yml
@@ -20,6 +20,8 @@ spec:
             - name: http
               containerPort: 3000
           env:
+            - name: USER
+              value: {{.Username}}
             - name: AUTH0_CLIENT_SECRET
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
This will be used in the oauth-proxy container to check the logged user
is the same user as the owner of the containter.