### PR TITLE
Users can list buckets in AWS Console (S3 policies)

### DIFF
--- a/infra/terraform/modules/data_buckets/iam.tf
+++ b/infra/terraform/modules/data_buckets/iam.tf
@@ -1,3 +1,10 @@
+# - The s3:GetBucketLocation and s3:ListAllMyBuckets actions are necessary
+#   to allow the user to see the buckets in the AWS console
+# - The s3:ListBucket action is necessary to allow users to list objects
+#   in a bucket
+#
+# See: https://aws.amazon.com/blogs/security/writing-iam-policies-how-to-grant-access-to-an-amazon-s3-bucket/
+
 resource "aws_iam_group" "managers" {
     name = "analytics-managers"
 }

--- a/infra/terraform/modules/data_buckets/iam.tf
+++ b/infra/terraform/modules/data_buckets/iam.tf
@@ -30,15 +30,18 @@ resource "aws_iam_group_policy" "managers_s3" {
       "Resource": "arn:aws:s3:::*"
     },
     {
-      "Sid": "SourceBucketManagersListBucket",
+      "Sid": "ManagersListBucketObjects",
       "Action": [
         "s3:ListBucket"
       ],
       "Effect": "Allow",
-      "Resource": "${aws_s3_bucket.source.arn}"
+      "Resource": [
+        "${aws_s3_bucket.source.arn}",
+        "${aws_s3_bucket.scratch.arn}"
+      ]
     },
     {
-      "Sid": "SourceBucketManagersReadWriteDeleteObjects",
+      "Sid": "ManagersReadWriteDeleteObjects",
       "Action": [
         "s3:DeleteObject",
         "s3:GetObject",
@@ -46,26 +49,10 @@ resource "aws_iam_group_policy" "managers_s3" {
         "s3:RestoreObject"
       ],
       "Effect": "Allow",
-      "Resource": "${aws_s3_bucket.source.arn}/*"
-    },
-    {
-      "Sid": "ScratchBucketManagersListBucket",
-      "Action": [
-        "s3:ListBucket"
-      ],
-      "Effect": "Allow",
-      "Resource": "${aws_s3_bucket.scratch.arn}"
-    },
-    {
-      "Sid": "ScratchBucketManagersReadWriteDeleteObjects",
-      "Action": [
-        "s3:DeleteObject",
-        "s3:GetObject",
-        "s3:PutObject",
-        "s3:RestoreObject"
-      ],
-      "Effect": "Allow",
-      "Resource": "${aws_s3_bucket.scratch.arn}/*"
+      "Resource": [
+        "${aws_s3_bucket.source.arn}/*",
+        "${aws_s3_bucket.scratch.arn}/*"
+      ]
     }
   ]
 }
@@ -89,12 +76,15 @@ resource "aws_iam_group_policy" "analysts_s3" {
       "Resource": "arn:aws:s3:::*"
     },
     {
-      "Sid": "SourceBucketAnalystsListBucket",
+      "Sid": "AnalystsListBucketObjects",
       "Action": [
         "s3:ListBucket"
       ],
       "Effect": "Allow",
-      "Resource": "${aws_s3_bucket.source.arn}"
+      "Resource": [
+        "${aws_s3_bucket.source.arn}",
+        "${aws_s3_bucket.scratch.arn}"
+      ]
     },
     {
       "Sid": "SourceBucketAnalystsReadOnly",
@@ -103,14 +93,6 @@ resource "aws_iam_group_policy" "analysts_s3" {
       ],
       "Effect": "Allow",
       "Resource": "${aws_s3_bucket.source.arn}/*"
-    },
-    {
-      "Sid": "ScratchBucketAnalystsListBucket",
-      "Action": [
-        "s3:ListBucket"
-      ],
-      "Effect": "Allow",
-      "Resource": "${aws_s3_bucket.scratch.arn}"
     },
     {
       "Sid": "ScratchBucketAnalystsReadWriteDeleteObjects",

--- a/infra/terraform/modules/data_buckets/iam.tf
+++ b/infra/terraform/modules/data_buckets/iam.tf
@@ -14,6 +14,15 @@ resource "aws_iam_group_policy" "managers_s3" {
   "Version": "2012-10-17",
   "Statement": [
     {
+      "Sid": "ManagersListAllBucketsInConsole",
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetBucketLocation",
+        "s3:ListAllMyBuckets"
+      ],
+      "Resource": "arn:aws:s3:::*"
+    },
+    {
       "Sid": "SourceBucketManagersListBucket",
       "Action": [
         "s3:ListBucket"
@@ -63,6 +72,15 @@ resource "aws_iam_group_policy" "analysts_s3" {
 {
   "Version": "2012-10-17",
   "Statement": [
+    {
+      "Sid": "AnalystsListAllBucketsInConsole",
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetBucketLocation",
+        "s3:ListAllMyBuckets"
+      ],
+      "Resource": "arn:aws:s3:::*"
+    },
     {
       "Sid": "SourceBucketAnalystsListBucket",
       "Action": [


### PR DESCRIPTION
From the AWS documentation:

> To list all buckets, users require the GetBucketLocation and ListAllMyBuckets actions for all resources in Amazon S3

Unfortunately **this will show the users all the buckets** (but they'll only
have access to the source/scratch one). From some of the comments on the
internet show only some of the buckets was not supported (yet).
But there may be a solution for this.

See: https://aws.amazon.com/blogs/security/writing-iam-policies-how-to-grant-access-to-an-amazon-s3-bucket/

Ticket: https://trello.com/c/yKYfs7cf