### PR TITLE
Added AWS lambda to encrypt S3 objects after upload

### DIFF
--- a/infra/terraform/env-dev/main.tf
+++ b/infra/terraform/env-dev/main.tf
@@ -53,3 +53,9 @@ module "logging_elasticsearch" {
     vpc_cidr = "${var.vpc_cidr}"
     ingress_ips = "${module.aws_vpc.nat_gateway_public_ips}"
 }
+
+module "lambda_functions" {
+    source = "../modules/lambda_functions"
+    bucket_id = "${module.data_buckets.scratch_bucket_id}"
+    bucket_arn = "${module.data_buckets.scratch_bucket_arn}"
+}

--- a/infra/terraform/modules/data_buckets/main.tf
+++ b/infra/terraform/modules/data_buckets/main.tf
@@ -21,6 +21,10 @@ output "iam_analysts_arn" {
     value = "${aws_iam_group.analysts.arn}"
 }
 
+output "scratch_bucket_id" {
+    value = "${aws_s3_bucket.scratch.id}"
+}
+
 output "shared_analyst_access_key_id" {
   value = "${aws_iam_access_key.shared_analyst.id}"
 }

--- a/infra/terraform/modules/lambda_functions/encrypt_s3_object/index.js
+++ b/infra/terraform/modules/lambda_functions/encrypt_s3_object/index.js
@@ -1,0 +1,53 @@
+'use strict';
+
+const aws = require('aws-sdk');
+
+const s3 = new aws.S3({ apiVersion: '2006-03-01' });
+
+
+exports.handler = (event, context, callback) => {
+    console.log('Received event:', JSON.stringify(event, null, 2));
+
+    // Get the object from the event and show its content type
+    const bucket = event.Records[0].s3.bucket.name;
+    const key = decodeURIComponent(event.Records[0].s3.object.key.replace(/\+/g, ' '));
+
+    console.log('key:', JSON.stringify(key, null, 2));
+    const getParams = {
+        Bucket: bucket,
+        Key: key,
+    };
+
+    s3.getObject(getParams, function(err, data) {
+        if (err) {
+            console.log(`Error getting object ${key} from bucket ${bucket}`);
+        } else {
+            // Only encrypt if not encrypted already
+            if (data.ServerSideEncryption !== 'AES256') {
+                console.log(`Unencrypted S3 object, key="${key}" bucket=${bucket}. Encrypting it...`);
+                // Copying an object into itself with encryption enabled
+                const copyParams = {
+                    CopySource: `${bucket}/${key}`,
+                    Bucket: bucket,
+                    Key: key,
+                    ServerSideEncryption: 'AES256',
+                };
+                s3.copyObject(copyParams, (err, data) => {
+                    if (err) {
+                        console.log(err);
+                        const error_msg = `Error encrypting object ${key} in bucket ${bucket}.`;
+                        console.log(error_msg);
+                        callback(error_msg);
+                    } else {
+                        const success_msg = `S3 object with key "${key}" in ${bucket} successfully encrypted`;
+                        console.log(success_msg);
+                        callback(null, success_msg);
+                    }
+                });
+            } else {
+                console.log(`SKIPPING ENCRYPTION...already encrypted! key="${key}" bucket=${bucket}.`);
+            }
+        }
+    });
+
+};

--- a/infra/terraform/modules/lambda_functions/encrypt_s3_object/index.js
+++ b/infra/terraform/modules/lambda_functions/encrypt_s3_object/index.js
@@ -20,7 +20,9 @@ exports.handler = (event, context, callback) => {
 
     s3.getObject(getParams, function(err, data) {
         if (err) {
-            console.log(`Error getting object ${key} from bucket ${bucket}`);
+            const error_msg = `Error getting object ${key} from bucket ${bucket}`;
+            console.log(error_msg);
+            callback(error_msg);
         } else {
             // Only encrypt if not encrypted already
             if (data.ServerSideEncryption !== 'AES256') {
@@ -45,9 +47,10 @@ exports.handler = (event, context, callback) => {
                     }
                 });
             } else {
-                console.log(`SKIPPING ENCRYPTION...already encrypted! key="${key}" bucket=${bucket}.`);
+                const success_msg = `SKIPPING ENCRYPTION...already encrypted! key="${key}" bucket=${bucket}.`;
+                console.log(success_msg);
+                callback(null, success_msg);
             }
         }
     });
-
 };

--- a/infra/terraform/modules/lambda_functions/encrypt_s3_object/package.json
+++ b/infra/terraform/modules/lambda_functions/encrypt_s3_object/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "encrypt-s3-object",
+  "version": "0.1.0",
+  "private": true,
+  "description": "AWS Lambda function to encrypt an S3 object",
+  "main": "index.js",
+  "author": "MoJ",
+  "license": "MIT",
+  "dependencies": {
+    "aws-sdk": "~2.22.0"
+  }
+}

--- a/infra/terraform/modules/lambda_functions/inputs.tf
+++ b/infra/terraform/modules/lambda_functions/inputs.tf
@@ -1,0 +1,3 @@
+variable "bucket_id" {}
+
+variable "bucket_arn" {}

--- a/infra/terraform/modules/lambda_functions/main.tf
+++ b/infra/terraform/modules/lambda_functions/main.tf
@@ -9,6 +9,7 @@ data "archive_file" "lambda_function_package" {
 resource "aws_lambda_function" "encrypt_s3_object" {
     description = "Encrypt S3 objects using AWS' server side encryption"
     filename = "${path.module}/encrypt_s3_object.zip"
+    source_code_hash = "${data.archive_file.lambda_function_package.output_base64sha256}"
     function_name = "encrypt_s3_object"
     role = "${aws_iam_role.encrypt_s3_object_role.arn}"
     handler = "index.handler"

--- a/infra/terraform/modules/lambda_functions/main.tf
+++ b/infra/terraform/modules/lambda_functions/main.tf
@@ -1,0 +1,50 @@
+// Lambda function which encrypts S3 objects
+resource "aws_lambda_function" "encrypt_s3_object" {
+    description = "Encrypt S3 objects using AWS' server side encryption"
+    filename = "encrypt_s3_object.zip"
+    function_name = "encrypt_s3_object"
+    role = "${aws_iam_role.encrypt_s3_object_role.arn}"
+    handler = "index.handler"
+    runtime = "nodejs4.3"
+}
+
+// Bucket notification to trigger lambda function
+resource "aws_s3_bucket_notification" "object_created_in_scratch" {
+    bucket = "${var.bucket_id}"
+    lambda_function {
+        lambda_function_arn = "${aws_lambda_function.encrypt_s3_object.arn}"
+        events = ["s3:ObjectCreated:*"]
+    }
+}
+
+// Role running the lambda function
+resource "aws_iam_role" "encrypt_s3_object_role" {
+    name = "encrypt_s3_object_role"
+    assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "CanEncryptS3Objects",
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetObject",
+        "s3:PutObject"
+      ],
+      "Resource": [
+        "${var.bucket_arn}/*"
+      ]
+    }
+  ]
+}
+EOF
+}
+
+// Permission to invoke the lambda function
+resource "aws_lambda_permission" "allow_encrypt_s3_object_invocation" {
+    statement_id = "AllowExecutionFromS3Bucket"
+    action = "lambda:InvokeFunction"
+    function_name = "${aws_lambda_function.encrypt_s3_object.arn}"
+    principal = "s3.amazonaws.com"
+    source_arn = "${var.bucket_arn}"
+}

--- a/infra/terraform/modules/lambda_functions/main.tf
+++ b/infra/terraform/modules/lambda_functions/main.tf
@@ -1,14 +1,22 @@
-// Lambda function which encrypts S3 objects
+# Zip the lambda function before the actual deploy
+data "archive_file" "lambda_function_package" {
+    type        = "zip"
+    source_dir  = "${path.module}/encrypt_s3_object"
+    output_path = "${path.module}/encrypt_s3_object.zip"
+}
+
+# Lambda function which encrypts S3 objects
 resource "aws_lambda_function" "encrypt_s3_object" {
     description = "Encrypt S3 objects using AWS' server side encryption"
-    filename = "encrypt_s3_object.zip"
+    filename = "${path.module}/encrypt_s3_object.zip"
     function_name = "encrypt_s3_object"
     role = "${aws_iam_role.encrypt_s3_object_role.arn}"
     handler = "index.handler"
     runtime = "nodejs4.3"
+    depends_on = ["data.archive_file.lambda_function_package"]
 }
 
-// Bucket notification to trigger lambda function
+# Bucket notification to trigger lambda function
 resource "aws_s3_bucket_notification" "object_created_in_scratch" {
     bucket = "${var.bucket_id}"
     lambda_function {
@@ -17,10 +25,30 @@ resource "aws_s3_bucket_notification" "object_created_in_scratch" {
     }
 }
 
-// Role running the lambda function
+# Role running the lambda function
 resource "aws_iam_role" "encrypt_s3_object_role" {
     name = "encrypt_s3_object_role"
     assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "lambda.amazonaws.com"
+      },
+      "Effect": "Allow"
+    }
+  ]
+}
+EOF
+}
+
+# Policies for the 'encrypt_s3_object_role' role
+resource "aws_iam_role_policy" "encrypt_s3_object_role_policy" {
+    name = "encrypt_s3_object_role_policy"
+    role = "${aws_iam_role.encrypt_s3_object_role.id}"
+    policy = <<EOF
 {
   "Version": "2012-10-17",
   "Statement": [
@@ -34,13 +62,26 @@ resource "aws_iam_role" "encrypt_s3_object_role" {
       "Resource": [
         "${var.bucket_arn}/*"
       ]
+    },
+    {
+      "Sid": "CanLog",
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents",
+        "logs:DescribeLogStreams"
+      ],
+      "Resource": [
+        "arn:aws:logs:*:*:*"
+      ]
     }
   ]
 }
 EOF
 }
 
-// Permission to invoke the lambda function
+# Permission to invoke the lambda function
 resource "aws_lambda_permission" "allow_encrypt_s3_object_invocation" {
     statement_id = "AllowExecutionFromS3Bucket"
     action = "lambda:InvokeFunction"


### PR DESCRIPTION
4 terraform resources are needed:
- The lambda function itself
- The role running the lambda function
- The notification from the S3 bucket when an S3 object is created
- The permission for the bucket to invoke the lambda function

I automated the lambda function packaging by using terraform's [`data "archive_file"`](https://www.terraform.io/docs/providers/archive/d/archive_file.html). The `aws_lambda_function` resource depends on it. This resource has also a `source_code_hash` attribute with its value depending on the zip archive file (to force a re-deploy when the lambda function change).