### PR TITLE
S3: Fixed permission problem preventing upload

### DIFF
--- a/infra/terraform/modules/data_buckets/iam.tf
+++ b/infra/terraform/modules/data_buckets/iam.tf
@@ -46,6 +46,7 @@ resource "aws_iam_group_policy" "managers_s3" {
         "s3:DeleteObject",
         "s3:GetObject",
         "s3:PutObject",
+        "s3:PutObjectAcl",
         "s3:RestoreObject"
       ],
       "Effect": "Allow",
@@ -100,6 +101,7 @@ resource "aws_iam_group_policy" "analysts_s3" {
         "s3:DeleteObject",
         "s3:GetObject",
         "s3:PutObject",
+        "s3:PutObjectAcl",
         "s3:RestoreObject"
       ],
       "Effect": "Allow",


### PR DESCRIPTION
I tested the upload with a user with only the 'analytics-managers' or
'analytics-analysts' role and they couldn't upload files.

They also need to perform the `s3:PutObjectAcl` action.