### PR TITLE
Improved performance of AWS Lambda to encrypt S3 objects

### DIFF
--- a/infra/terraform/modules/lambda_functions/encrypt_s3_object/index.js
+++ b/infra/terraform/modules/lambda_functions/encrypt_s3_object/index.js
@@ -13,12 +13,12 @@ exports.handler = (event, context, callback) => {
     const key = decodeURIComponent(event.Records[0].s3.object.key.replace(/\+/g, ' '));
 
     console.log('key:', JSON.stringify(key, null, 2));
-    const getParams = {
+    const headParams = {
         Bucket: bucket,
         Key: key,
     };
 
-    s3.getObject(getParams, function(err, data) {
+    s3.headObject(headParams, function(err, data) {
         if (err) {
             const error_msg = `Error getting object ${key} from bucket ${bucket}`;
             console.log(error_msg);

--- a/infra/terraform/modules/lambda_functions/main.tf
+++ b/infra/terraform/modules/lambda_functions/main.tf
@@ -14,6 +14,7 @@ resource "aws_lambda_function" "encrypt_s3_object" {
     role = "${aws_iam_role.encrypt_s3_object_role.arn}"
     handler = "index.handler"
     runtime = "nodejs4.3"
+    timeout = 300 # 5 minutes
     depends_on = ["data.archive_file.lambda_function_package"]
 }
 


### PR DESCRIPTION
Using S3's headObject() rather than getObject() to improve the performances.

There is a [spreadsheet with the times](https://docs.google.com/a/digital.justice.gov.uk/spreadsheets/d/1LntDAdTFKpnOT_37tjVraPdZ_cVQLBu-xdrn14jay5o/edit?usp=sharing) the lambda function takes depending on the file size.
