### PR TITLE
Create a separate AWS lambda function per environment

### DIFF
--- a/infra/terraform/environments/alpha/main.tf
+++ b/infra/terraform/environments/alpha/main.tf
@@ -54,3 +54,10 @@ module "logging_elasticsearch" {
     vpc_cidr = "${var.vpc_cidr}"
     ingress_ips = "${module.aws_vpc.nat_gateway_public_ips}"
 }
+
+module "lambda_functions" {
+    source = "../../modules/lambda_functions"
+    env = "${var.env}"
+    bucket_id = "${module.data_buckets.scratch_bucket_id}"
+    bucket_arn = "${module.data_buckets.scratch_bucket_arn}"
+}

--- a/infra/terraform/environments/dev/main.tf
+++ b/infra/terraform/environments/dev/main.tf
@@ -57,6 +57,7 @@ module "logging_elasticsearch" {
 
 module "lambda_functions" {
     source = "../../modules/lambda_functions"
+    env = "${var.env}"
     bucket_id = "${module.data_buckets.scratch_bucket_id}"
     bucket_arn = "${module.data_buckets.scratch_bucket_arn}"
 }

--- a/infra/terraform/environments/example/main.tf
+++ b/infra/terraform/environments/example/main.tf
@@ -54,3 +54,10 @@ module "logging_elasticsearch" {
     vpc_cidr = "${var.vpc_cidr}"
     ingress_ips = "${module.aws_vpc.nat_gateway_public_ips}"
 }
+
+module "lambda_functions" {
+    source = "../../modules/lambda_functions"
+    env = "${var.env}"
+    bucket_id = "${module.data_buckets.scratch_bucket_id}"
+    bucket_arn = "${module.data_buckets.scratch_bucket_arn}"
+}

--- a/infra/terraform/modules/lambda_functions/inputs.tf
+++ b/infra/terraform/modules/lambda_functions/inputs.tf
@@ -1,3 +1,4 @@
-variable "bucket_id" {}
+variable "env" {}
 
+variable "bucket_id" {}
 variable "bucket_arn" {}

--- a/infra/terraform/modules/lambda_functions/main.tf
+++ b/infra/terraform/modules/lambda_functions/main.tf
@@ -10,7 +10,7 @@ resource "aws_lambda_function" "encrypt_s3_object" {
     description = "Encrypt S3 objects using AWS' server side encryption"
     filename = "${path.module}/encrypt_s3_object.zip"
     source_code_hash = "${data.archive_file.lambda_function_package.output_base64sha256}"
-    function_name = "encrypt_s3_object"
+    function_name = "${var.env}_encrypt_s3_object"
     role = "${aws_iam_role.encrypt_s3_object_role.arn}"
     handler = "index.handler"
     runtime = "nodejs4.3"


### PR DESCRIPTION
For example the `alpha` environment will have an `alpha_encrypt_s3_object` lambda function in it.

I also added this terraform module to the example and alpha environments.