### PR TITLE
RStudio: Use docker image with Cloudyr preinstalled

### DIFF
--- a/jenkinsfiles/deploy_rstudio_for_user.groovy
+++ b/jenkinsfiles/deploy_rstudio_for_user.groovy
@@ -11,6 +11,7 @@ node {
         DOMAIN=\$(echo -n "${env.DOMAIN}"|base64 -w 0)
         CALLBACK_URL=\$(echo -n "https://\${USERNAME}.rstudio.${TOOLS_DOMAIN}/callback"|base64 -w 0)
         COOKIE_SECRET=\$(echo -n "${env.COOKIE_SECRET}"|base64 -w 0)
+        AWS_DEFAULT_REGION=${env.AWS_DEFAULT_REGION}
         AWS_ACCESS_KEY_ID=\$(echo -n "${env.AWS_ACCESS_KEY_ID}"|base64 -w 0)
         AWS_SECRET_ACCESS_KEY=\$(echo -n "${AWS_SECRET_ACCESS_KEY}"|base64 -w 0)
 
@@ -25,6 +26,7 @@ node {
                 -e s/{{\\.DomainB64}}/\${DOMAIN}/g \\
                 -e s/{{\\.CallbackURLB64}}/\${CALLBACK_URL}/g \\
                 -e s/{{\\.CookieSecretB64}}/\${COOKIE_SECRET}/g \\
+                -e s/{{\\.AWSDefaultRegion}}/\${AWS_DEFAULT_REGION}/g \\
                 -e s/{{\\.AWSAccessKeyIDB64}}/\${AWS_ACCESS_KEY_ID}/g \\
                 -e s/{{\\.AWSSecretAccessKeyB64}}/\${AWS_SECRET_ACCESS_KEY}/g \\
             | kubectl apply -n user-\${USERNAME} -f -

--- a/k8s-templates/r-studio-user/deployment.yml
+++ b/k8s-templates/r-studio-user/deployment.yml
@@ -68,6 +68,8 @@ spec:
           env:
             - name: USER
               value: {{.Username}}
+            - name: AWS_DEFAULT_REGION
+              value: {{.AWSDefaultRegion}}
             - name: AWS_ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:

--- a/k8s-templates/r-studio-user/deployment.yml
+++ b/k8s-templates/r-studio-user/deployment.yml
@@ -60,7 +60,7 @@ spec:
             periodSeconds: 5
 
         - name: r-studio-server
-          image: quay.io/mojanalytics/rstudio:8a7454fb
+          image: quay.io/mojanalytics/rstudio:3948a04b
           imagePullPolicy: Always
           ports:
             - name: http


### PR DESCRIPTION
See: ministryofjustice/analytics-platform-rstudio#2

Also updated Jenkins `deploy_rstudio_for_user` job to set `AWS_DEFAULT_REGION` which is needed by cloudyr (and maybe other libraries).

**NOTE**: I didn't put the `AWS_DEFAULT_REGION` value in a k8s secret as this is not really a secret so base64 it seemed overkill.