### PR TITLE
RStudio Chart: Bump docker image version

### DIFF
--- a/charts/rstudio/Chart.yaml
+++ b/charts/rstudio/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for RStudio
 name: rstudio
-version: 0.1.0
+version: 0.1.1

--- a/charts/rstudio/templates/deployment.yml
+++ b/charts/rstudio/templates/deployment.yml
@@ -61,7 +61,7 @@ spec:
             periodSeconds: 5
 
         - name: r-studio-server
-          image: quay.io/mojanalytics/rstudio:3948a04b
+          image: quay.io/mojanalytics/rstudio:3846e3d7
           imagePullPolicy: Always
           ports:
             - name: http


### PR DESCRIPTION
This is to set the `AWS_DEFAULT_REGION` environment variable for the user

See: https://github.com/ministryofjustice/analytics-platform-rstudio/pull/3