### PR TITLE
Enable adding multiple users at once

### DIFF
--- a/jenkinsfiles/grant_access_to_app.groovy
+++ b/jenkinsfiles/grant_access_to_app.groovy
@@ -20,17 +20,17 @@ node {
     // Creates passwordless user in Auth0 and adds to app group
     // NOTE: Groups provided by Auth0 Authorization Extension
     stage ("Create Auth0 passwordless user and add to app group") {
+      env.AUTHZ_API_ID = 'urn:auth0-authz-api'
       withCredentials([
-        usernamePassword(
-            credentialsId: 'auth0-mgmt-api',
-            usernameVariable: 'CLIENT_ID',
-            passwordVariable: 'CLIENT_SECRET'),
         string(
-            credentialsId: 'authz_api_url',
+            credentialsId: 'AUTH0_CLIENT_ID',
+            variable: 'CLIENT_ID'),
+        string(
+            credentialsId: 'AUTH0_CLIENT_SECRET',
+            variable: 'CLIENT_SECRET'),
+        string(
+            credentialsId: 'AUTHZ_API',
             variable: 'AUTHZ_API_URL'),
-        string(
-            credentialsId: 'authz_api_id',
-            variable: 'AUTHZ_API_ID'),
         string(
             credentialsId: 'AUTH0_DOMAIN',
             variable: 'AUTH0_DOMAIN')

--- a/jenkinsfiles/grant_access_to_app.groovy
+++ b/jenkinsfiles/grant_access_to_app.groovy
@@ -1,5 +1,18 @@
 node {
 
+    properties([
+        parameters([
+            string(
+                name: 'APP_NAME',
+                description: 'Shiny App name',
+                defaultValue: ''),
+            string(
+                name: 'EMAILS',
+                description: 'Semicolon delimited list of email addresses',
+                defaultValue: ''),
+        ])
+    ])
+
     stage ("Git checkout") {
         checkout scm
     }
@@ -22,7 +35,7 @@ node {
             credentialsId: 'AUTH0_DOMAIN',
             variable: 'AUTH0_DOMAIN')
       ]) {
-        sh "/usr/local/bin/grant_access ${env.APP_NAME} ${env.EMAIL}"
+        sh "/usr/local/bin/grant_access ${env.APP_NAME} ${env.EMAILS}"
       }
     }
 }


### PR DESCRIPTION
## What

* Move build parameters into Jenkinsfile
* Call updated python script with list of email addresses

## How to review

1. Run the `grant-access-to-app` Control Panel Jenkins job
2. See the parameters are now "APP_NAME" and "EMAILS"
3. Enter multiple email addresses separated by semicolons (`;`)
4. See the job run
5. See users with the given email addresses have been granted access to the specified app

See [Enable user to provide semicolon delimited list of email addresses as part of the Jenkins grant-access job](https://trello.com/c/L5cA87Mn)