### PR TITLE
Terraform alpha env: Pass `dns_zone_id` to `logging_elasticsearch` module

### DIFF
--- a/infra/terraform/environments/alpha/main.tf
+++ b/infra/terraform/environments/alpha/main.tf
@@ -61,6 +61,7 @@ module "logging_elasticsearch" {
     domain_name = "logging-${var.env}"
     vpc_cidr = "${var.vpc_cidr}"
     ingress_ips = "${module.aws_vpc.nat_gateway_public_ips}"
+    dns_zone_id = "${module.cluster_dns.dns_zone_id}"
     instance_count = 3
 }
 


### PR DESCRIPTION
## What

Tried to run `$ terraform plan` in the `alpha` environment but it complained about the missing `dns_zone_id` variable in the `logging_elasticsearch` module (as part of [Kerin's work on ES](https://github.com/ministryofjustice/analytics-platform-ops/pull/47))

## How to review

1. Run `$ terraform plan`
2. Does it return an error?
3. If not this fixes the problem