### PR TITLE
GH Webhooks handler responds 202 ACCEPTED as it should.

### DIFF
--- a/infra/terraform/modules/data_access/github_webhooks_handler/github_webhooks.py
+++ b/infra/terraform/modules/data_access/github_webhooks_handler/github_webhooks.py
@@ -34,7 +34,7 @@ def publish_to_sns(event, context):
             topic=topic_arn(event["headers"]["X-GitHub-Event"]),
             message=message
         )
-        return response(201, "Event published to SNS")
+        return response(202, "Event published to SNS")
     except SNSTopicNotFound as error:
         return response(404, "SNS topic '{}' not found".format(error))
 

--- a/infra/terraform/modules/data_access/github_webhooks_handler/tests/test_publish_to_sns.py
+++ b/infra/terraform/modules/data_access/github_webhooks_handler/tests/test_publish_to_sns.py
@@ -42,6 +42,6 @@ def test_publish_success(event):
     response = github_webhooks.publish_to_sns(event, "context not used")
     response_body = json.loads(response["body"])
 
-    assert response["statusCode"] == 201
+    assert response["statusCode"] == 202
     assert response_body["message"] == "Event published to SNS"
     assert response["headers"]["Content-Type"] == "application/json"


### PR DESCRIPTION
## What

The GH Webhooks handler don't process the GH events directly but rather submit them to AWS SNS for later processing.
So respond with a `202 ACCEPTED` is more appropriate.

## Why

See GOV.UK's Style [Guidelines on API](https://github.com/alphagov/styleguides/blob/master/api.md):

> Use 202 for times when the data is valid, but we've queued
> the persistence for background processing, as described in
> RFC 7231:

> "The request has been accepted for processing, but the
> processing has not been completed.
