### PR TITLE
Define resource (CPU, RAM) limits for RStudio containers (auth-proxy…

### DIFF
--- a/charts/rstudio/templates/deployment.yml
+++ b/charts/rstudio/templates/deployment.yml
@@ -62,6 +62,8 @@ spec:
               port: http
             initialDelaySeconds: 5
             periodSeconds: 5
+          resources:
+{{ toYaml .Values.AuthProxy.resources | indent 12 }}
 
         - name: fluentd
           image: "{{ .Values.Fluentd.Image.Repository }}:{{ .Values.Fluentd.Image.Tag }}"
@@ -82,6 +84,8 @@ spec:
               mountPath: /fluentd/etc
             - name: varlogrstudioserver
               mountPath: /var/log/rstudio-server
+          resources:
+{{ toYaml .Values.Fluentd.resources | indent 12 }}
 
         - name: r-studio-server
           image: "{{ .Values.RStudio.Image.Repository }}:{{ .Values.RStudio.Image.Tag }}"

--- a/charts/rstudio/values.yaml
+++ b/charts/rstudio/values.yaml
@@ -17,14 +17,34 @@ Fluentd:
     Repository: quay.io/fluent/fluentd-kubernetes-daemonset
     Tag: latest
     PullPolicy: "IfNotPresent"
+  resources:
+    limits:
+      cpu: 100m
+      memory: 128Mi
+    requests:
+      cpu: 25m
+      memory: 64Mi
 AuthProxy:
   Image:
     Repository: quay.io/mojanalytics/rstudio-auth-proxy
     Tag: "a750b612"
     PullPolicy: "IfNotPresent"
+  resources:
+    limits:
+      cpu: 100m
+      memory: 128Mi
+    requests:
+      cpu: 25m
+      memory: 64Mi
 RStudio:
   Image:
     Repository: quay.io/mojanalytics/rstudio
     Tag: "v1.1.2"
     PullPolicy: "IfNotPresent"
-  resources: {}
+  resources:
+    limits:
+      cpu: 1.5
+      memory: 6Gi
+    requests:
+      cpu: 200m
+      memory: 1Gi


### PR DESCRIPTION
## What

CPU/RAM resource requests and limits have been defined for all three containers in an RStudio deployment.

- Resource _requests_ are guaranteed to a given pod, and represent the absolute minimum resources that a pod will have access to.
- Resource _limits_ are ceiling values - if a pod exceeds these limits, the Kubernetes scheduler will kill the pod. Note that this is _not_ the same thing as limiting the amount of resources available to the pod. There is an associated RStudio [pull request](https://github.com/ministryofjustice/analytics-platform-rstudio/pull/9) which defines a memory limit within RStudio itself.

Resource _requests_ have been set at a low level initially - 200m CPUs (0.2 of a core) and 1GB RAM - largely to ensure that rstudio instances are spread out relatively evenly over nodes in the cluster. With these values each cluster node will run around 5 or 6 RStudio instances.

Resource _limits_ have been set at a relatively high level - 1.5 CPU cores and 6GB of RAM - this is to ensure that a single RStudio instance does not consume all 2 cores and 8GB of RAM on an m4.large EC2 instances.

With these values in place, resource allocation on a given node will look something like this:

```
Allocated resources:
  (Total limits may be over 100 percent, i.e., overcommitted.)
  CPU Requests	CPU Limits	Memory Requests	Memory Limits
  ------------	----------	---------------	-------------
  1870m (93%)	8600m (430%)	6244Mi (78%)	32128Mi (402%)
```

In the above, RStudio pods have been allocated their requested minimum resources, with limits overcommited, allowing each RStudio pod to burst to use available extra resources.

## How to review

1. Check out changes
2. Ensure a reasonable number of platform users are present in the dev environment (circa 20)
3. Deploy an RStudio instance for each user - [this bash script](https://gist.github.com/kerin/0368e264551e45429119201c8a0e737d) will deploy an instance for each defined user
4. Run `$ kubectl describe node -l kubernetes.io/role=node` to view the distribution of RStudio pods across the cluster
5. Stress test individual instances by allocating large amounts of RAM and consuming large amounts of CPU - an instance on a given node utilising large amounts of resources should not result in a loss of service for other instances on the same node