### PR TITLE
Added SNS topic: ${ENV}_github_organization_events

### DIFF
--- a/infra/terraform/modules/data_access/topics.tf
+++ b/infra/terraform/modules/data_access/topics.tf
@@ -1,5 +1,12 @@
 # See: https://developer.github.com/webhooks/#events
 
+# Topic for GH organization events
+#
+# See: https://developer.github.com/v3/activity/events/types/#organizationevent
+resource "aws_sns_topic" "github_organization_events" {
+  name = "${var.env}_github_organization_events"
+}
+
 # Topic for GH membership events
 #
 # See: https://developer.github.com/v3/activity/events/types/#membershipevent


### PR DESCRIPTION
When members will be added to the organisation we'll create a corresponding
IAM role for them.

**Ticket**: https://trello.com/c/vYuW5G7n/115-create-sns-queues-for-each-github-event-type-we-re-interested-in-user-joined-left-org-team-created-user-joined-left-team