### PR TITLE
Handle GitHub "organization" events to add/remove IAM roles in AWS

### DIFF
--- a/infra/terraform/environments/dev/main.tf
+++ b/infra/terraform/environments/dev/main.tf
@@ -110,4 +110,6 @@ module "data_access" {
 
     env = "${var.env}"
     account_id = "${data.aws_caller_identity.current.account_id}"
+
+    organization_events_topic_arn = "${module.notifications.organization_events_topic_arn}"
 }

--- a/infra/terraform/environments/dev/main.tf
+++ b/infra/terraform/environments/dev/main.tf
@@ -104,3 +104,10 @@ module "notifications" {
 
     gh_hook_secret = "${var.gh_hook_secret}"
 }
+
+module "data_access" {
+    source = "../../modules/data_access"
+
+    env = "${var.env}"
+    account_id = "${data.aws_caller_identity.current.account_id}"
+}

--- a/infra/terraform/modules/data_access/inputs.tf
+++ b/infra/terraform/modules/data_access/inputs.tf
@@ -1,2 +1,4 @@
 variable "account_id" {}
 variable "env" {}
+
+variable "organization_events_topic_arn" {}

--- a/infra/terraform/modules/data_access/inputs.tf
+++ b/infra/terraform/modules/data_access/inputs.tf
@@ -1,3 +1,2 @@
-# variable "region" {}
-# variable "account_id" {}
-# variable "env" {}
+variable "account_id" {}
+variable "env" {}

--- a/infra/terraform/modules/data_access/lambda_assume_role_policy_document.tf
+++ b/infra/terraform/modules/data_access/lambda_assume_role_policy_document.tf
@@ -1,0 +1,10 @@
+data "aws_iam_policy_document" "lambda_assume_role" {
+    statement {
+        actions = ["sts:AssumeRole"]
+        effect = "Allow"
+        principals = {
+            type = "Service"
+            identifiers = ["lambda.amazonaws.com"]
+        }
+    }
+}

--- a/infra/terraform/modules/data_access/lambda_organization_events.tf
+++ b/infra/terraform/modules/data_access/lambda_organization_events.tf
@@ -1,0 +1,97 @@
+# Zip the lambda function before the actual deploy
+data "archive_file" "organization_events_zip" {
+    type        = "zip"
+    source_dir  = "${path.module}/organization_events"
+    output_path = "/tmp/organization_events.zip"
+}
+
+# Lambda function which handles GH organization events
+resource "aws_lambda_function" "organization_events" {
+    description = "Updates IAM resources in response to GH organization events"
+    filename = "/tmp/organization_events.zip"
+    source_code_hash = "${data.archive_file.organization_events_zip.output_base64sha256}"
+    function_name = "${var.env}_organization_events"
+    role = "${aws_iam_role.organization_events_role.arn}"
+    handler = "organization_events.event_received"
+    runtime = "python3.6"
+    timeout = 10
+    depends_on = ["data.archive_file.organization_events_zip"]
+    environment {
+        variables = {
+            CREATE_ROLE_ARN = "${aws_lambda_function.create_user_role.arn}",
+            DELETE_ROLE_ARN = "${aws_lambda_function.delete_user_role.arn}",
+        }
+    }
+}
+
+# Lambda function triggered by SNS notification
+resource "aws_sns_topic_subscription" "organization_events" {
+    topic_arn = "${var.organization_events_topic_arn}"
+    protocol = "lambda"
+    endpoint = "${aws_lambda_function.organization_events.arn}"
+}
+
+# Role running the lambda function
+resource "aws_iam_role" "organization_events_role" {
+    name = "${var.env}_organization_events_role"
+    assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "lambda.amazonaws.com"
+      },
+      "Effect": "Allow"
+    }
+  ]
+}
+EOF
+}
+
+# Policies for the 'organization_events_role' role
+resource "aws_iam_role_policy" "organization_events_role_policy" {
+    name = "${var.env}_organization_events_role_policy"
+    role = "${aws_iam_role.organization_events_role.id}"
+    policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "CanInvokeLambdaFunctions",
+      "Effect": "Allow",
+      "Action": [
+        "lambda:InvokeFunction"
+      ],
+      "Resource": [
+        "${aws_lambda_function.create_user_role.arn}",
+        "${aws_lambda_function.delete_user_role.arn}"
+      ]
+    },
+    {
+      "Sid": "CanLog",
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents",
+        "logs:DescribeLogStreams"
+      ],
+      "Resource": [
+        "arn:aws:logs:*:*:*"
+      ]
+    }
+  ]
+}
+EOF
+}
+
+# Permission to invoke the lambda function
+resource "aws_lambda_permission" "allow_organization_events_invocation" {
+    statement_id = "AllowExecutionFromSNS"
+    action = "lambda:InvokeFunction"
+    function_name = "${aws_lambda_function.organization_events.arn}"
+    principal = "sns.amazonaws.com"
+    source_arn = "${var.organization_events_topic_arn}"
+}

--- a/infra/terraform/modules/data_access/lambda_organization_events.tf
+++ b/infra/terraform/modules/data_access/lambda_organization_events.tf
@@ -31,6 +31,15 @@ resource "aws_sns_topic_subscription" "organization_events" {
     endpoint = "${aws_lambda_function.organization_events.arn}"
 }
 
+# Permission to invoke the lambda function
+resource "aws_lambda_permission" "allow_organization_events_invocation" {
+    statement_id = "AllowExecutionFromSNS"
+    action = "lambda:InvokeFunction"
+    function_name = "${aws_lambda_function.organization_events.arn}"
+    principal = "sns.amazonaws.com"
+    source_arn = "${var.organization_events_topic_arn}"
+}
+
 # Role running the lambda function
 resource "aws_iam_role" "organization_events_role" {
     name = "${var.env}_organization_events_role"
@@ -85,13 +94,4 @@ resource "aws_iam_role_policy" "organization_events_role_policy" {
   ]
 }
 EOF
-}
-
-# Permission to invoke the lambda function
-resource "aws_lambda_permission" "allow_organization_events_invocation" {
-    statement_id = "AllowExecutionFromSNS"
-    action = "lambda:InvokeFunction"
-    function_name = "${aws_lambda_function.organization_events.arn}"
-    principal = "sns.amazonaws.com"
-    source_arn = "${var.organization_events_topic_arn}"
 }

--- a/infra/terraform/modules/data_access/lambda_organization_events.tf
+++ b/infra/terraform/modules/data_access/lambda_organization_events.tf
@@ -43,20 +43,7 @@ resource "aws_lambda_permission" "allow_organization_events_invocation" {
 # Role running the lambda function
 resource "aws_iam_role" "organization_events_role" {
     name = "${var.env}_organization_events_role"
-    assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": "sts:AssumeRole",
-      "Principal": {
-        "Service": "lambda.amazonaws.com"
-      },
-      "Effect": "Allow"
-    }
-  ]
-}
-EOF
+    assume_role_policy = "${data.aws_iam_policy_document.lambda_assume_role.json}"
 }
 
 # Policies for the 'organization_events_role' role

--- a/infra/terraform/modules/data_access/lambda_users.tf
+++ b/infra/terraform/modules/data_access/lambda_users.tf
@@ -18,8 +18,8 @@ resource "aws_lambda_function" "create_user_role" {
     depends_on = ["data.archive_file.users_zip"]
     environment {
         variables = {
-            ACCOUNT_ID = "${var.account_id}",
             STAGE = "${var.env}",
+            SAML_PROVIDER_ARN = "arn:aws:iam::${var.account_id}:saml-provider/auth0",
         }
     }
 }
@@ -128,7 +128,9 @@ resource "aws_iam_role_policy" "delete_user_role_policy" {
       "Sid": "CanDeleteRoles",
       "Effect": "Allow",
       "Action": [
-        "iam:DeleteRole"
+        "iam:DeleteRole",
+        "iam:ListAttachedRolePolicies",
+        "iam:DetachRolePolicy"
       ],
       "Resource": [
         "arn:aws:iam::${var.account_id}:role/users/${var.env}_*"

--- a/infra/terraform/modules/data_access/lambda_users.tf
+++ b/infra/terraform/modules/data_access/lambda_users.tf
@@ -27,20 +27,7 @@ resource "aws_lambda_function" "create_user_role" {
 # Role assumed by the 'create_user_role' lambda function
 resource "aws_iam_role" "create_user_role" {
     name = "${var.env}_create_user_role"
-    assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": "sts:AssumeRole",
-      "Principal": {
-        "Service": "lambda.amazonaws.com"
-      },
-      "Effect": "Allow"
-    }
-  ]
-}
-EOF
+    assume_role_policy = "${data.aws_iam_policy_document.lambda_assume_role.json}"
 }
 
 # Policies for the 'create_user_role' role
@@ -100,20 +87,7 @@ resource "aws_lambda_function" "delete_user_role" {
 # Role assumed by the 'delete_user_role' lambda function
 resource "aws_iam_role" "delete_user_role" {
     name = "${var.env}_delete_user_role"
-    assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": "sts:AssumeRole",
-      "Principal": {
-        "Service": "lambda.amazonaws.com"
-      },
-      "Effect": "Allow"
-    }
-  ]
-}
-EOF
+    assume_role_policy = "${data.aws_iam_policy_document.lambda_assume_role.json}"
 }
 
 # Policies for the 'delete_user_role' role

--- a/infra/terraform/modules/data_access/lambda_users.tf
+++ b/infra/terraform/modules/data_access/lambda_users.tf
@@ -1,0 +1,153 @@
+# Zip the lambda function before the actual deploy
+data "archive_file" "users_zip" {
+    type        = "zip"
+    source_dir  = "${path.module}/users"
+    output_path = "/tmp/users.zip"
+}
+
+# Lambda function adds an IAM role given its username
+resource "aws_lambda_function" "create_user_role" {
+    description = "Adds an IAM role for the given user"
+    filename = "/tmp/users.zip"
+    source_code_hash = "${data.archive_file.users_zip.output_base64sha256}"
+    function_name = "${var.env}_create_user_role"
+    role = "${aws_iam_role.create_user_role.arn}"
+    handler = "users.create_user_role"
+    runtime = "python3.6"
+    timeout = 10
+    depends_on = ["data.archive_file.users_zip"]
+    environment {
+        variables = {
+            ACCOUNT_ID = "${var.account_id}",
+            STAGE = "${var.env}",
+        }
+    }
+}
+
+# Role assumed by the 'create_user_role' lambda function
+resource "aws_iam_role" "create_user_role" {
+    name = "${var.env}_create_user_role"
+    assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "lambda.amazonaws.com"
+      },
+      "Effect": "Allow"
+    }
+  ]
+}
+EOF
+}
+
+# Policies for the 'create_user_role' role
+resource "aws_iam_role_policy" "create_user_role_policy" {
+    name = "${var.env}_create_user_role_policy"
+    role = "${aws_iam_role.create_user_role.id}"
+    policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "CanCreateRoles",
+      "Effect": "Allow",
+      "Action": [
+        "iam:CreateRole"
+      ],
+      "Resource": [
+        "arn:aws:iam::${var.account_id}:role/users/${var.env}_*"
+      ]
+    },
+    {
+      "Sid": "CanLog",
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents",
+        "logs:DescribeLogStreams"
+      ],
+      "Resource": [
+        "arn:aws:logs:*:*:*"
+      ]
+    }
+  ]
+}
+EOF
+}
+
+# Lambda function delete an IAM role given its username
+resource "aws_lambda_function" "delete_user_role" {
+    description = "Delete the IAM role for the given user"
+    filename = "/tmp/users.zip"
+    source_code_hash = "${data.archive_file.users_zip.output_base64sha256}"
+    function_name = "${var.env}_delete_user_role"
+    role = "${aws_iam_role.delete_user_role.arn}"
+    handler = "users.delete_user_role"
+    runtime = "python3.6"
+    timeout = 10
+    depends_on = ["data.archive_file.users_zip"]
+    environment {
+        variables = {
+            STAGE = "${var.env}",
+        }
+    }
+}
+
+# Role assumed by the 'delete_user_role' lambda function
+resource "aws_iam_role" "delete_user_role" {
+    name = "${var.env}_delete_user_role"
+    assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "lambda.amazonaws.com"
+      },
+      "Effect": "Allow"
+    }
+  ]
+}
+EOF
+}
+
+# Policies for the 'delete_user_role' role
+resource "aws_iam_role_policy" "delete_user_role_policy" {
+    name = "${var.env}_delete_user_role_policy"
+    role = "${aws_iam_role.delete_user_role.id}"
+    policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "CanDeleteRoles",
+      "Effect": "Allow",
+      "Action": [
+        "iam:DeleteRole"
+      ],
+      "Resource": [
+        "arn:aws:iam::${var.account_id}:role/users/${var.env}_*"
+      ]
+    },
+    {
+      "Sid": "CanLog",
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents",
+        "logs:DescribeLogStreams"
+      ],
+      "Resource": [
+        "arn:aws:logs:*:*:*"
+      ]
+    }
+  ]
+}
+EOF
+}

--- a/infra/terraform/modules/data_access/organization_events/organization_events.py
+++ b/infra/terraform/modules/data_access/organization_events/organization_events.py
@@ -1,0 +1,54 @@
+import json
+import os
+
+import boto3
+
+
+LAMBDA_ARNS = {
+    "create_user_role": os.environ["CREATE_ROLE_ARN"],
+    "delete_user_role": os.environ["DELETE_ROLE_ARN"],
+}
+
+
+def event_received(sns_event, context):
+    print("SNS event received = {}".format(json.dumps(sns_event)))
+    for record in sns_event["Records"]:
+        event = json.loads(record["Sns"]["Message"])
+        action = event["action"]
+        if action == "member_added":
+            member_added(event)
+        elif action == "member_removed":
+            member_removed(event)
+
+
+def member_added(event):
+    print("Handling 'member_added' event: {}".format(event))
+
+    invoke_lambda(
+        function=LAMBDA_ARNS["create_user_role"],
+        payload=payload(event)
+    )
+
+
+def member_removed(event):
+    print("Handling 'member_removed' event: {}".format(event))
+
+    invoke_lambda(
+        function=LAMBDA_ARNS["delete_user_role"],
+        payload=payload(event)
+    )
+
+
+def invoke_lambda(function, payload):
+    client = boto3.client("lambda")
+    client.invoke(
+        FunctionName=function,
+        Payload=bytes(json.dumps(payload), "utf8"),
+        InvocationType="Event",
+    )
+
+
+def payload(event):
+    return {
+        "username": event["membership"]["user"]["login"],
+    }

--- a/infra/terraform/modules/data_access/organization_events/organization_events.py
+++ b/infra/terraform/modules/data_access/organization_events/organization_events.py
@@ -4,39 +4,22 @@ import os
 import boto3
 
 
-LAMBDA_ARNS = {
-    "create_user_role": os.environ["CREATE_ROLE_ARN"],
-    "delete_user_role": os.environ["DELETE_ROLE_ARN"],
-}
-
-
 def event_received(sns_event, context):
+    EVENT_HANDLERS = {
+        "member_added": os.environ["CREATE_ROLE_ARN"],
+        "member_removed": os.environ["DELETE_ROLE_ARN"],
+    }
+
     print("SNS event received = {}".format(json.dumps(sns_event)))
     for record in sns_event["Records"]:
         event = json.loads(record["Sns"]["Message"])
         action = event["action"]
-        if action == "member_added":
-            member_added(event)
-        elif action == "member_removed":
-            member_removed(event)
 
-
-def member_added(event):
-    print("Handling 'member_added' event: {}".format(event))
-
-    invoke_lambda(
-        function=LAMBDA_ARNS["create_user_role"],
-        payload=payload(event)
-    )
-
-
-def member_removed(event):
-    print("Handling 'member_removed' event: {}".format(event))
-
-    invoke_lambda(
-        function=LAMBDA_ARNS["delete_user_role"],
-        payload=payload(event)
-    )
+        if action in EVENT_HANDLERS:
+            invoke_lambda(
+                function=EVENT_HANDLERS[action],
+                payload=payload(event)
+            )
 
 
 def invoke_lambda(function, payload):

--- a/infra/terraform/modules/data_access/organization_events/organization_events.py
+++ b/infra/terraform/modules/data_access/organization_events/organization_events.py
@@ -1,7 +1,23 @@
 import json
+import logging
 import os
 
 import boto3
+
+
+'''
+Environment variables:
+ - CREATE_ROLE_ARN, ARN of the lambda function to create the IAM role
+ - DELETE_ROLE_ARN, ARN of the lambda function to delete the IAM role
+ - LOG_LEVEL, change the logging level (default is "DEBUG"). Must be one of
+   the python logging supported levels: "CRITICAL", "ERROR", "WARNING",
+   "INFO" or "DEBUG" (See: https://docs.python.org/2/library/logging.html#logging-levels)
+'''
+
+
+LOG = logging.getLogger(__package__)
+LOG_LEVEL = os.environ.get("LOG_LEVEL", "DEBUG")
+LOG.setLevel(LOG_LEVEL)
 
 
 def event_received(sns_event, context):
@@ -10,7 +26,7 @@ def event_received(sns_event, context):
         "member_removed": os.environ["DELETE_ROLE_ARN"],
     }
 
-    print("SNS event received = {}".format(json.dumps(sns_event)))
+    LOG.debug("SNS event received = {}".format(json.dumps(sns_event)))
     for record in sns_event["Records"]:
         event = json.loads(record["Sns"]["Message"])
         action = event["action"]

--- a/infra/terraform/modules/data_access/organization_events/requirements.dev.txt
+++ b/infra/terraform/modules/data_access/organization_events/requirements.dev.txt
@@ -1,0 +1,5 @@
+boto3
+
+pytest
+pytest-spec
+pytest-watch

--- a/infra/terraform/modules/data_access/organization_events/tests/conftest.py
+++ b/infra/terraform/modules/data_access/organization_events/tests/conftest.py
@@ -1,0 +1,85 @@
+import json
+import mock
+
+import boto3
+import pytest
+
+
+TEST_CREATE_ROLE_ARN = "arn:aws:iam::123456789012:lambda/create_role"
+TEST_DELETE_ROLE_ARN = "arn:aws:iam::123456789012:lambda/delete_role"
+TEST_USERNAME = "alice"
+
+
+@pytest.yield_fixture
+def given_the_env_is_set():
+    with mock.patch.dict("os.environ", {
+        "CREATE_ROLE_ARN": TEST_CREATE_ROLE_ARN,
+        "DELETE_ROLE_ARN": TEST_DELETE_ROLE_ARN,
+    }):
+        yield
+
+
+@pytest.fixture
+def payload_bytes():
+    return bytes(
+        json.dumps({"username": TEST_USERNAME}),
+        "utf8"
+    )
+
+
+@pytest.fixture
+def lambda_client_mock():
+    return mock.create_autospec(boto3.client("lambda"))
+
+
+@pytest.yield_fixture
+def given_lambda_is_available(lambda_client_mock):
+    with mock.patch.object(boto3, "client", return_value=lambda_client_mock):
+        yield
+
+
+@pytest.fixture
+def member_added_event():
+    return sns_event(
+        github_event("member_added", TEST_USERNAME)
+    )
+
+
+@pytest.fixture
+def member_removed_event():
+    return sns_event(
+        github_event("member_removed", TEST_USERNAME)
+    )
+
+
+def github_event(action, username):
+    return {
+        "action": action,
+        "membership": {
+            "user": {
+                "login": TEST_USERNAME,
+            }
+        }
+    }
+
+
+def sns_event(github_event):
+    return {
+        "Records": [
+            {
+                "Sns": {
+                    "Message": json.dumps(github_event),
+                }
+            }
+        ]
+    }
+
+
+@pytest.fixture
+def create_role_arn():
+    return TEST_CREATE_ROLE_ARN
+
+
+@pytest.fixture
+def delete_role_arn():
+    return TEST_DELETE_ROLE_ARN

--- a/infra/terraform/modules/data_access/organization_events/tests/test_organization_events.py
+++ b/infra/terraform/modules/data_access/organization_events/tests/test_organization_events.py
@@ -1,0 +1,35 @@
+import boto3
+from botocore.exceptions import ClientError
+import pytest
+
+import organization_events
+
+
+@pytest.mark.usefixtures(
+    "given_the_env_is_set",
+    "given_lambda_is_available",
+)
+def test_event_received_member_added(lambda_client_mock, member_added_event, create_role_arn, payload_bytes):
+    organization_events.event_received(member_added_event, None)
+
+    # Test right lambda function is invoked asyncronously
+    lambda_client_mock.invoke.assert_called_with(
+        FunctionName=create_role_arn,
+        Payload=payload_bytes,
+        InvocationType="Event",
+    )
+
+
+@pytest.mark.usefixtures(
+    "given_the_env_is_set",
+    "given_lambda_is_available",
+)
+def test_event_received_member_removed(lambda_client_mock, member_removed_event, delete_role_arn, payload_bytes):
+    organization_events.event_received(member_removed_event, None)
+
+    # Test right lambda function is invoked asyncronously
+    lambda_client_mock.invoke.assert_called_with(
+        FunctionName=delete_role_arn,
+        Payload=payload_bytes,
+        InvocationType="Event",
+    )

--- a/infra/terraform/modules/data_access/users/requirements.dev.txt
+++ b/infra/terraform/modules/data_access/users/requirements.dev.txt
@@ -1,0 +1,9 @@
+boto3
+
+# moto's implementation of IAM's delete_role is in a branch currently
+# moto
+git+git://github.com/JackDanger/moto.git@implement_iam_delete_role#egg=moto
+
+pytest
+pytest-spec
+pytest-watch

--- a/infra/terraform/modules/data_access/users/requirements.dev.txt
+++ b/infra/terraform/modules/data_access/users/requirements.dev.txt
@@ -1,9 +1,5 @@
 boto3
 
-# moto's implementation of IAM's delete_role is in a branch currently
-# moto
-git+git://github.com/spulec/moto.git@584352a#egg=moto
-
 pytest
 pytest-spec
 pytest-watch

--- a/infra/terraform/modules/data_access/users/requirements.dev.txt
+++ b/infra/terraform/modules/data_access/users/requirements.dev.txt
@@ -2,7 +2,7 @@ boto3
 
 # moto's implementation of IAM's delete_role is in a branch currently
 # moto
-git+git://github.com/JackDanger/moto.git@implement_iam_delete_role#egg=moto
+git+git://github.com/spulec/moto.git@584352a#egg=moto
 
 pytest
 pytest-spec

--- a/infra/terraform/modules/data_access/users/tests/conftest.py
+++ b/infra/terraform/modules/data_access/users/tests/conftest.py
@@ -1,14 +1,15 @@
 import json
-from unittest.mock import patch
+import mock
 
 import boto3
-from moto import mock_iam
 import pytest
 
 
-TEST_ACCOUNT_ID = "123456789012"
+TEST_SAML_PROVIDER_ARN = "arn:aws:iam::123456789012:saml-provider/auth0"
 TEST_STAGE = "test"
 TEST_USERNAME = "alice"
+
+TEST_ROLE_POLICY_ARN = "test_policy_arn"
 
 
 @pytest.fixture
@@ -18,9 +19,9 @@ def username():
 
 @pytest.yield_fixture
 def given_the_env_is_set():
-    with patch.dict("os.environ", {
-        "ACCOUNT_ID": TEST_ACCOUNT_ID,
+    with mock.patch.dict("os.environ", {
         "STAGE": TEST_STAGE,
+        "SAML_PROVIDER_ARN": TEST_SAML_PROVIDER_ARN,
     }):
         yield
 
@@ -33,9 +34,57 @@ def role_name():
     )
 
 
+@pytest.fixture
+def trust_relationship():
+    return {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Principal": {
+                    "Federated": TEST_SAML_PROVIDER_ARN,
+                },
+                "Action": "sts:AssumeRoleWithSAML",
+                "Condition": {
+                    "StringEquals": {
+                        "SAML:aud": "https://signin.aws.amazon.com/saml"
+                    }
+                }
+            }
+        ]
+    }
+
+
+@pytest.fixture
+def role_policy_arn():
+    return TEST_ROLE_POLICY_ARN
+
+
+@pytest.fixture
+def role_policies(role_policy_arn):
+    return {
+        "AttachedPolicies": [
+            {
+                "PolicyArn": role_policy_arn,
+            }
+        ]
+    }
+
+
+@pytest.fixture
+def iam_client_mock(role_policies):
+    client = mock.create_autospec(boto3.client("iam"))
+
+    client.list_attached_role_policies = mock.Mock(
+        return_value=role_policies
+    )
+
+    return client
+
+
 @pytest.yield_fixture
-def given_iam_is_available():
-    with mock_iam():
+def given_iam_is_available(iam_client_mock):
+    with mock.patch.object(boto3, "client", return_value=iam_client_mock):
         yield
 
 

--- a/infra/terraform/modules/data_access/users/tests/conftest.py
+++ b/infra/terraform/modules/data_access/users/tests/conftest.py
@@ -1,0 +1,49 @@
+import json
+from unittest.mock import patch
+
+import boto3
+from moto import mock_iam
+import pytest
+
+
+TEST_ACCOUNT_ID = "123456789012"
+TEST_STAGE = "test"
+TEST_USERNAME = "alice"
+
+
+@pytest.fixture
+def username():
+    return TEST_USERNAME
+
+
+@pytest.yield_fixture
+def given_the_env_is_set():
+    with patch.dict("os.environ", {
+        "ACCOUNT_ID": TEST_ACCOUNT_ID,
+        "STAGE": TEST_STAGE,
+    }):
+        yield
+
+
+@pytest.fixture
+def role_name():
+    return "{env}_{username}_role".format(
+        env=TEST_STAGE,
+        username=TEST_USERNAME,
+    )
+
+
+@pytest.yield_fixture
+def given_iam_is_available():
+    with mock_iam():
+        yield
+
+
+@pytest.fixture
+def given_the_role_exists(role_name):
+    client = boto3.client("iam")
+    client.create_role(
+        RoleName=role_name,
+        Path="/users/",
+        AssumeRolePolicyDocument="a trust relationship policy",
+    )

--- a/infra/terraform/modules/data_access/users/tests/conftest.py
+++ b/infra/terraform/modules/data_access/users/tests/conftest.py
@@ -86,13 +86,3 @@ def iam_client_mock(role_policies):
 def given_iam_is_available(iam_client_mock):
     with mock.patch.object(boto3, "client", return_value=iam_client_mock):
         yield
-
-
-@pytest.fixture
-def given_the_role_exists(role_name):
-    client = boto3.client("iam")
-    client.create_role(
-        RoleName=role_name,
-        Path="/users/",
-        AssumeRolePolicyDocument="a trust relationship policy",
-    )

--- a/infra/terraform/modules/data_access/users/tests/test_create_user_role.py
+++ b/infra/terraform/modules/data_access/users/tests/test_create_user_role.py
@@ -1,0 +1,19 @@
+import boto3
+from botocore.exceptions import ClientError
+import pytest
+
+import users
+
+
+@pytest.mark.usefixtures(
+    "given_the_env_is_set",
+    "given_iam_is_available",
+)
+def test_create_user_role_success(username, role_name):
+    users.create_user_role({"username": username}, None)
+
+    try:
+        client = boto3.client("iam")
+        role = client.get_role(RoleName=role_name)
+    except Exception:
+        pytest.fail("Failed to read the role. Was it created?")

--- a/infra/terraform/modules/data_access/users/tests/test_create_user_role.py
+++ b/infra/terraform/modules/data_access/users/tests/test_create_user_role.py
@@ -1,5 +1,5 @@
-import boto3
-from botocore.exceptions import ClientError
+import json
+
 import pytest
 
 import users
@@ -9,11 +9,12 @@ import users
     "given_the_env_is_set",
     "given_iam_is_available",
 )
-def test_create_user_role_success(username, role_name):
+def test_create_user_role_success(iam_client_mock, username, role_name, trust_relationship):
     users.create_user_role({"username": username}, None)
 
-    try:
-        client = boto3.client("iam")
-        role = client.get_role(RoleName=role_name)
-    except Exception:
-        pytest.fail("Failed to read the role. Was it created?")
+    # Test role is created
+    iam_client_mock.create_role.assert_called_with(
+        RoleName=role_name,
+        Path="/users/",
+        AssumeRolePolicyDocument=json.dumps(trust_relationship),
+    )

--- a/infra/terraform/modules/data_access/users/tests/test_delete_user_role.py
+++ b/infra/terraform/modules/data_access/users/tests/test_delete_user_role.py
@@ -1,0 +1,18 @@
+import boto3
+from botocore.exceptions import ClientError
+import pytest
+
+import users
+
+
+@pytest.mark.usefixtures(
+    "given_the_env_is_set",
+    "given_iam_is_available",
+    "given_the_role_exists",
+)
+def test_delete_user_role_success(username, role_name):
+    users.delete_user_role({"username": username}, None)
+
+    with pytest.raises(Exception):
+        client = boto3.client("iam")
+        role = client.get_role(RoleName=role_name)

--- a/infra/terraform/modules/data_access/users/users.py
+++ b/infra/terraform/modules/data_access/users/users.py
@@ -1,0 +1,62 @@
+import json
+import os
+
+import boto3
+
+
+'''
+Environment variables:
+ - STAGE, e.g. "dev", "alpha", etc...
+ - ACCOUNT_ID, AWS Account ID
+'''
+
+
+def create_user_role(event, context):
+    """
+    Creates the role for the given user
+
+    event = {"username": "alice"}
+    """
+    trust_relationship = {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Principal": {
+                    "Federated": "arn:aws:iam::{}:saml-provider/auth0".format(os.environ["ACCOUNT_ID"])
+                },
+                "Action": "sts:AssumeRoleWithSAML",
+                "Condition": {
+                    "StringEquals": {
+                        "SAML:aud": "https://signin.aws.amazon.com/saml"
+                    }
+                }
+            }
+        ]
+    }
+
+    client = boto3.client("iam")
+    client.create_role(
+        RoleName=role_name(event["username"]),
+        Path="/users/",
+        AssumeRolePolicyDocument=json.dumps(trust_relationship),
+    )
+
+
+def delete_user_role(event, context):
+    """
+    Deletes the role for the given user
+
+    event = {"username": "alice"}
+    """
+    client = boto3.client("iam")
+    client.delete_role(
+        RoleName=role_name(event["username"])
+    )
+
+
+def role_name(username):
+    return "{env}_{username}_role".format(
+        env=os.environ["STAGE"],
+        username=username,
+    )

--- a/infra/terraform/modules/notifications/outputs.tf
+++ b/infra/terraform/modules/notifications/outputs.tf
@@ -1,3 +1,15 @@
 output "github_webhooks_handler_arn" {
   value = "${aws_lambda_function.github_webhooks_handler.arn}"
 }
+
+output "organization_events_topic_arn" {
+  value = "${aws_sns_topic.github_organization_events.arn}"
+}
+
+output "membership_events_topic_arn" {
+  value = "${aws_sns_topic.github_membership_events.arn}"
+}
+
+output "team_events_topic_arn" {
+  value = "${aws_sns_topic.github_team_events.arn}"
+}


### PR DESCRIPTION
## What

This is to handle the organization GitHub events arriving from the corresponding SNS topic (`${ENV}_github_organization_events`)

These events are handled by the `organization_events` "controller" lambda function which then invoke the `create_user_role`/`delete_user_role` asyncrounously.

**NOTE**: The `delete_user_role` lambda function has to detach all the role's policies before being able to delete it.


## Ticket:

Part of ticket: https://trello.com/c/UZ8qooqO/116-xl-create-lambda-functions-to-consume-github-events-from-sns-queues-and-create-update-delete-aws-resources

## TODO / Ideas

- [x] Test the "controller" function
- [x] Test better the users' lambda functions?