### PR TITLE
Amendments to as per Andy comments (PR #62)

### DIFF
--- a/infra/terraform/modules/data_access/lambda_organization_events.tf
+++ b/infra/terraform/modules/data_access/lambda_organization_events.tf
@@ -18,8 +18,8 @@ resource "aws_lambda_function" "organization_events" {
     depends_on = ["data.archive_file.organization_events_zip"]
     environment {
         variables = {
-            CREATE_ROLE_ARN = "${aws_lambda_function.create_user_role.arn}",
-            DELETE_ROLE_ARN = "${aws_lambda_function.delete_user_role.arn}",
+            LAMBDA_CREATE_ROLE_ARN = "${aws_lambda_function.create_user_role.arn}",
+            LAMBDA_DELETE_ROLE_ARN = "${aws_lambda_function.delete_user_role.arn}",
         }
     }
 }

--- a/infra/terraform/modules/data_access/organization_events/tests/conftest.py
+++ b/infra/terraform/modules/data_access/organization_events/tests/conftest.py
@@ -8,23 +8,17 @@ import pytest
 TEST_CREATE_ROLE_ARN = "arn:aws:iam::123456789012:lambda/create_role"
 TEST_DELETE_ROLE_ARN = "arn:aws:iam::123456789012:lambda/delete_role"
 TEST_USERNAME = "alice"
+TEST_PAYLOAD = {"username": TEST_USERNAME}
+TEST_PAYLOAD_BYTES = json.dumps(TEST_PAYLOAD).encode("utf8")
 
 
 @pytest.yield_fixture
 def given_the_env_is_set():
     with mock.patch.dict("os.environ", {
-        "CREATE_ROLE_ARN": TEST_CREATE_ROLE_ARN,
-        "DELETE_ROLE_ARN": TEST_DELETE_ROLE_ARN,
+        "LAMBDA_CREATE_ROLE_ARN": TEST_CREATE_ROLE_ARN,
+        "LAMBDA_DELETE_ROLE_ARN": TEST_DELETE_ROLE_ARN,
     }):
         yield
-
-
-@pytest.fixture
-def payload_bytes():
-    return bytes(
-        json.dumps({"username": TEST_USERNAME}),
-        "utf8"
-    )
 
 
 @pytest.fixture
@@ -38,22 +32,8 @@ def given_lambda_is_available(lambda_client_mock):
         yield
 
 
-@pytest.fixture
-def member_added_event():
-    return sns_event(
-        github_event("member_added", TEST_USERNAME)
-    )
-
-
-@pytest.fixture
-def member_removed_event():
-    return sns_event(
-        github_event("member_removed", TEST_USERNAME)
-    )
-
-
-def github_event(action, username):
-    return {
+def sns_event(action):
+    github_event = {
         "action": action,
         "membership": {
             "user": {
@@ -62,8 +42,6 @@ def github_event(action, username):
         }
     }
 
-
-def sns_event(github_event):
     return {
         "Records": [
             {
@@ -73,13 +51,3 @@ def sns_event(github_event):
             }
         ]
     }
-
-
-@pytest.fixture
-def create_role_arn():
-    return TEST_CREATE_ROLE_ARN
-
-
-@pytest.fixture
-def delete_role_arn():
-    return TEST_DELETE_ROLE_ARN

--- a/infra/terraform/modules/data_access/organization_events/tests/test_organization_events.py
+++ b/infra/terraform/modules/data_access/organization_events/tests/test_organization_events.py
@@ -5,31 +5,24 @@ import pytest
 import organization_events
 
 
+from tests.conftest import sns_event, TEST_PAYLOAD_BYTES, TEST_CREATE_ROLE_ARN, \
+    TEST_DELETE_ROLE_ARN
+
+
+@pytest.mark.parametrize("event,lambda_arn", [
+    (sns_event("member_added"), TEST_CREATE_ROLE_ARN),
+    (sns_event("member_removed"), TEST_DELETE_ROLE_ARN)
+])
 @pytest.mark.usefixtures(
     "given_the_env_is_set",
     "given_lambda_is_available",
 )
-def test_event_received_member_added(lambda_client_mock, member_added_event, create_role_arn, payload_bytes):
-    organization_events.event_received(member_added_event, None)
+def test_when_event_received_is_handled(lambda_client_mock, event, lambda_arn):
+    organization_events.event_received(event, None)
 
     # Test right lambda function is invoked asyncronously
     lambda_client_mock.invoke.assert_called_with(
-        FunctionName=create_role_arn,
-        Payload=payload_bytes,
-        InvocationType="Event",
-    )
-
-
-@pytest.mark.usefixtures(
-    "given_the_env_is_set",
-    "given_lambda_is_available",
-)
-def test_event_received_member_removed(lambda_client_mock, member_removed_event, delete_role_arn, payload_bytes):
-    organization_events.event_received(member_removed_event, None)
-
-    # Test right lambda function is invoked asyncronously
-    lambda_client_mock.invoke.assert_called_with(
-        FunctionName=delete_role_arn,
-        Payload=payload_bytes,
+        FunctionName=lambda_arn,
+        Payload=TEST_PAYLOAD_BYTES,
         InvocationType="Event",
     )

--- a/infra/terraform/modules/data_access/users/tests/conftest.py
+++ b/infra/terraform/modules/data_access/users/tests/conftest.py
@@ -8,13 +8,9 @@ import pytest
 TEST_SAML_PROVIDER_ARN = "arn:aws:iam::123456789012:saml-provider/auth0"
 TEST_STAGE = "test"
 TEST_USERNAME = "alice"
+TEST_ROLE_NAME = "{}_{}_role".format(TEST_STAGE, TEST_USERNAME)
 
 TEST_ROLE_POLICY_ARN = "test_policy_arn"
-
-
-@pytest.fixture
-def username():
-    return TEST_USERNAME
 
 
 @pytest.yield_fixture
@@ -24,14 +20,6 @@ def given_the_env_is_set():
         "SAML_PROVIDER_ARN": TEST_SAML_PROVIDER_ARN,
     }):
         yield
-
-
-@pytest.fixture
-def role_name():
-    return "{env}_{username}_role".format(
-        env=TEST_STAGE,
-        username=TEST_USERNAME,
-    )
 
 
 @pytest.fixture
@@ -56,27 +44,18 @@ def trust_relationship():
 
 
 @pytest.fixture
-def role_policy_arn():
-    return TEST_ROLE_POLICY_ARN
+def iam_client_mock():
+    client = mock.create_autospec(boto3.client("iam"))
 
-
-@pytest.fixture
-def role_policies(role_policy_arn):
-    return {
+    attached_policies = {
         "AttachedPolicies": [
             {
-                "PolicyArn": role_policy_arn,
+                "PolicyArn": TEST_ROLE_POLICY_ARN,
             }
         ]
     }
-
-
-@pytest.fixture
-def iam_client_mock(role_policies):
-    client = mock.create_autospec(boto3.client("iam"))
-
     client.list_attached_role_policies = mock.Mock(
-        return_value=role_policies
+        return_value=attached_policies
     )
 
     return client

--- a/infra/terraform/modules/data_access/users/tests/test_create_user_role.py
+++ b/infra/terraform/modules/data_access/users/tests/test_create_user_role.py
@@ -4,17 +4,19 @@ import pytest
 
 import users
 
+from tests.conftest import TEST_ROLE_NAME, TEST_USERNAME
+
 
 @pytest.mark.usefixtures(
     "given_the_env_is_set",
     "given_iam_is_available",
 )
-def test_create_user_role_success(iam_client_mock, username, role_name, trust_relationship):
-    users.create_user_role({"username": username}, None)
+def test_create_user_role_success(iam_client_mock, trust_relationship):
+    users.create_user_role({"username": TEST_USERNAME}, None)
 
     # Test role is created
     iam_client_mock.create_role.assert_called_with(
-        RoleName=role_name,
+        RoleName=TEST_ROLE_NAME,
         Path="/users/",
         AssumeRolePolicyDocument=json.dumps(trust_relationship),
     )

--- a/infra/terraform/modules/data_access/users/tests/test_delete_user_role.py
+++ b/infra/terraform/modules/data_access/users/tests/test_delete_user_role.py
@@ -2,21 +2,23 @@ import pytest
 
 import users
 
+from tests.conftest import TEST_ROLE_NAME, TEST_USERNAME, TEST_ROLE_POLICY_ARN
+
 
 @pytest.mark.usefixtures(
     "given_the_env_is_set",
     "given_iam_is_available",
 )
-def test_delete_user_role_success(iam_client_mock, username, role_name, role_policy_arn):
-    users.delete_user_role({"username": username}, None)
+def test_delete_user_role_success(iam_client_mock):
+    users.delete_user_role({"username": TEST_USERNAME}, None)
 
     # Test detaches policies
     iam_client_mock.detach_role_policy.assert_called_with(
-        RoleName=role_name,
-        PolicyArn=role_policy_arn,
+        RoleName=TEST_ROLE_NAME,
+        PolicyArn=TEST_ROLE_POLICY_ARN,
     )
 
     # Test role is deleted
     iam_client_mock.delete_role.assert_called_with(
-        RoleName=role_name
+        RoleName=TEST_ROLE_NAME
     )


### PR DESCRIPTION
- Using `str#encode` instead of `bytes()`
- Renamed environment variables to be explicit about the fact
  these ARNs belongs to lambda functions
- Moved module documentation at the beginning of the file
- Using `getLogger(__name__)` instead of `__package__`
- Inline lambda functions payload instead of having it in a
  function
- Removed some of the tests fixtures and used pytest's parametrize
  to remove some duplication

See [PR #62: Handle GitHub "organization" events to add/remove IAM roles in AWS](https://github.com/ministryofjustice/analytics-platform-ops/pull/62#pullrequestreview-40250908)