### PR TITLE
Add lambda function to create team bucket policies

### DIFF
--- a/infra/terraform/modules/data_access/lambda_team_events.tf
+++ b/infra/terraform/modules/data_access/lambda_team_events.tf
@@ -19,8 +19,8 @@ resource "aws_lambda_function" "team_events" {
     environment {
         variables = {
             LAMBDA_CREATE_TEAM_BUCKET_ARN = "${aws_lambda_function.create_team_bucket.arn}",
+            LAMBDA_CREATE_TEAM_BUCKET_POLICIES_ARN = "${aws_lambda_function.create_team_bucket_policies.arn}",
             # TODO: Change with real ARNs. Fake for now
-            LAMBDA_CREATE_TEAM_BUCKET_POLICIES_ARN = "TODO: fake ARN",
             LAMBDA_DELETE_TEAM_BUCKET_POLICIES_ARN = "TODO: fake ARN",
         }
     }
@@ -64,7 +64,8 @@ resource "aws_iam_role_policy" "team_events_role_policy" {
         "lambda:InvokeFunction"
       ],
       "Resource": [
-        "${aws_lambda_function.create_team_bucket.arn}"
+        "${aws_lambda_function.create_team_bucket.arn}",
+        "${aws_lambda_function.create_team_bucket_policies.arn}"
       ]
     },
     {

--- a/infra/terraform/modules/data_access/lambda_teams.tf
+++ b/infra/terraform/modules/data_access/lambda_teams.tf
@@ -65,3 +65,63 @@ resource "aws_iam_role_policy" "create_team_bucket" {
 }
 EOF
 }
+
+# Lambda function to create policies for a team S3 bucket
+resource "aws_lambda_function" "create_team_bucket_policies" {
+    description = "Creates policies for the team S3 bucket"
+    filename = "/tmp/teams.zip"
+    source_code_hash = "${data.archive_file.teams_zip.output_base64sha256}"
+    function_name = "${var.env}_create_team_bucket_policies"
+    role = "${aws_iam_role.create_team_bucket_policies.arn}"
+    handler = "teams.create_team_bucket_policies"
+    runtime = "python3.6"
+    timeout = 10
+    depends_on = ["data.archive_file.teams_zip"]
+    environment {
+        variables = {
+            STAGE = "${var.env}",
+        }
+    }
+}
+
+# Role assumed by the 'create_team_bucket_policies' lambda function
+resource "aws_iam_role" "create_team_bucket_policies" {
+    name = "${var.env}_create_team_bucket_policies"
+    assume_role_policy = "${data.aws_iam_policy_document.lambda_assume_role.json}"
+}
+
+# Policies for the 'create_team_bucket_policies' role
+resource "aws_iam_role_policy" "create_team_bucket_policies" {
+    name = "${var.env}_create_team_bucket_policies"
+    role = "${aws_iam_role.create_team_bucket_policies.id}"
+    policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "CanCreateIAMPolicies",
+      "Effect": "Allow",
+      "Action": [
+        "iam:CreatePolicy"
+      ],
+      "Resource": [
+        "arn:aws:iam::${var.account_id}:policy/teams/${var.env}-*"
+      ]
+    },
+    {
+      "Sid": "CanLog",
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents",
+        "logs:DescribeLogStreams"
+      ],
+      "Resource": [
+        "arn:aws:logs:*:*:*"
+      ]
+    }
+  ]
+}
+EOF
+}

--- a/infra/terraform/modules/data_access/teams/teams.py
+++ b/infra/terraform/modules/data_access/teams/teams.py
@@ -38,5 +38,96 @@ def create_team_bucket(event, context):
     )
 
 
+def create_team_bucket_policies(event, context):
+    """
+    Creates the policies for the team S3 bucket:
+      - a "readonly" policy and
+      - a "readwrite" policy
+
+    event = {"team": {"slug": "justice-league"}}
+    """
+    bucket = bucket_name(event["team"]["slug"])
+
+    create_policy(
+        name="{}-readonly".format(bucket),
+        bucket=bucket,
+        readwrite=False,
+    )
+
+    create_policy(
+        name="{}-readwrite".format(bucket),
+        bucket=bucket,
+        readwrite=True,
+    )
+
+
+def create_policy(name, bucket, readwrite):
+    LOG.debug("Creating '{}' policy".format(name))
+
+    policy_document = get_policy_document(bucket, readwrite)
+
+    client = boto3.client("iam")
+    client.create_policy(
+        PolicyName=name,
+        Path="/teams/",
+        PolicyDocument=json.dumps(policy_document),
+    )
+
+
+def get_policy_document(bucket, readwrite):
+    bucket_arn = "arn:aws:s3:::{}".format(bucket)
+
+    statements = [
+        {
+            "Sid": "ListBucketsInConsole",
+            "Effect": "Allow",
+            "Action": [
+                "s3:GetBucketLocation",
+                "s3:ListAllMyBuckets"
+            ],
+            "Resource": "arn:aws:s3:::*"
+        },
+        {
+            "Sid": "ListObjects",
+            "Action": [
+                "s3:ListBucket"
+            ],
+            "Effect": "Allow",
+            "Resource": [bucket_arn],
+        },
+        {
+            "Sid": "ReadObjects",
+            "Action": [
+                "s3:GetObject",
+                "s3:GetObjectAcl",
+                "s3:GetObjectVersion",
+            ],
+            "Effect": "Allow",
+            "Resource": "{}/*".format(bucket_arn)
+        },
+    ]
+
+    if readwrite:
+        statements.append(
+            {
+                "Sid": "UpdateRenameAndDeleteObjects",
+                "Action": [
+                    "s3:DeleteObject",
+                    "s3:DeleteObjectVersion",
+                    "s3:PutObject",
+                    "s3:PutObjectAcl",
+                    "s3:RestoreObject",
+                ],
+                "Effect": "Allow",
+                "Resource": "{}/*".format(bucket_arn)
+            }
+        )
+
+    return {
+        "Version": "2012-10-17",
+        "Statement": statements,
+    }
+
+
 def bucket_name(slug):
     return "{}-{}".format(os.environ["STAGE"], slug)

--- a/infra/terraform/modules/data_access/teams/tests/conftest.py
+++ b/infra/terraform/modules/data_access/teams/tests/conftest.py
@@ -1,3 +1,4 @@
+import copy
 import json
 import mock
 
@@ -9,6 +10,54 @@ TEST_BUCKET_REGION = "eu-west-1"
 TEST_STAGE = "test"
 TEST_TEAM_SLUG = "justice-league"
 TEST_BUCKET_NAME = "{}-{}".format(TEST_STAGE, TEST_TEAM_SLUG)
+TEST_BUCKET_ARN = "arn:aws:s3:::{}".format(TEST_BUCKET_NAME)
+TEST_READONLY_POLICY_DOCUMENT = {
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "ListBucketsInConsole",
+            "Effect": "Allow",
+            "Action": [
+                "s3:GetBucketLocation",
+                "s3:ListAllMyBuckets"
+            ],
+            "Resource": "arn:aws:s3:::*"
+        },
+        {
+            "Sid": "ListObjects",
+            "Action": [
+                "s3:ListBucket"
+            ],
+            "Effect": "Allow",
+            "Resource": [TEST_BUCKET_ARN],
+        },
+        {
+            "Sid": "ReadObjects",
+            "Action": [
+                "s3:GetObject",
+                "s3:GetObjectAcl",
+                "s3:GetObjectVersion",
+            ],
+            "Effect": "Allow",
+            "Resource": "{}/*".format(TEST_BUCKET_ARN)
+        },
+    ],
+}
+TEST_READWRITE_POLICY_DOCUMENT = copy.deepcopy(TEST_READONLY_POLICY_DOCUMENT)
+TEST_READWRITE_POLICY_DOCUMENT["Statement"].append(
+    {
+        "Sid": "UpdateRenameAndDeleteObjects",
+        "Action": [
+            "s3:DeleteObject",
+            "s3:DeleteObjectVersion",
+            "s3:PutObject",
+            "s3:PutObjectAcl",
+            "s3:RestoreObject",
+        ],
+        "Effect": "Allow",
+        "Resource": "{}/*".format(TEST_BUCKET_ARN)
+    }
+)
 
 
 @pytest.yield_fixture
@@ -21,8 +70,19 @@ def given_the_env_is_set():
 
 
 @pytest.fixture
+def iam_client_mock():
+    return mock.create_autospec(boto3.client("iam"))
+
+
+@pytest.fixture
 def s3_client_mock():
     return mock.create_autospec(boto3.client("s3"))
+
+
+@pytest.yield_fixture
+def given_iam_is_available(iam_client_mock):
+    with mock.patch.object(boto3, "client", return_value=iam_client_mock):
+        yield
 
 
 @pytest.yield_fixture

--- a/infra/terraform/modules/data_access/teams/tests/test_create_team_bucket_policies.py
+++ b/infra/terraform/modules/data_access/teams/tests/test_create_team_bucket_policies.py
@@ -5,8 +5,12 @@ import pytest
 
 import teams
 
-from tests.conftest import TEST_TEAM_SLUG, TEST_READONLY_POLICY_DOCUMENT, \
-    TEST_READWRITE_POLICY_DOCUMENT, TEST_BUCKET_NAME
+from tests.conftest import (
+    TEST_BUCKET_NAME,
+    TEST_READONLY_POLICY_DOCUMENT,
+    TEST_READWRITE_POLICY_DOCUMENT,
+    TEST_TEAM_SLUG,
+)
 
 
 @pytest.mark.usefixtures(

--- a/infra/terraform/modules/data_access/teams/tests/test_create_team_bucket_policies.py
+++ b/infra/terraform/modules/data_access/teams/tests/test_create_team_bucket_policies.py
@@ -1,0 +1,32 @@
+import json
+from mock import call
+
+import pytest
+
+import teams
+
+from tests.conftest import TEST_TEAM_SLUG, TEST_READONLY_POLICY_DOCUMENT, \
+    TEST_READWRITE_POLICY_DOCUMENT, TEST_BUCKET_NAME
+
+
+@pytest.mark.usefixtures(
+    "given_the_env_is_set",
+    "given_iam_is_available",
+)
+def test_when_the_team_is_created_the_bucket_policies_are_created(iam_client_mock):
+    teams.create_team_bucket_policies({"team": {"slug": TEST_TEAM_SLUG}}, None)
+
+    calls = [
+        call(
+            PolicyName="{}-readonly".format(TEST_BUCKET_NAME),
+            Path="/teams/",
+            PolicyDocument=json.dumps(TEST_READONLY_POLICY_DOCUMENT),
+        ),
+        call(
+            PolicyName="{}-readwrite".format(TEST_BUCKET_NAME),
+            Path="/teams/",
+            PolicyDocument=json.dumps(TEST_READWRITE_POLICY_DOCUMENT),
+        )
+    ]
+
+    iam_client_mock.create_policy.assert_has_calls(calls)


### PR DESCRIPTION
## What

This lambda function will create a read-only IAM policy and a read/write IAM policy.

The read-only policy has the following permissions:
 - list buckets in AWS console
 - list objects in the team bucket
 - read objects in the team bucket

The read/write policy has all the permissions in the read-only one plus:
 - can delete/rename/update/restore objects and their ACL in the team bucket

## When/How is called?

This lambda function is invoked asyncronously by the `team_event`
lambda when a team is created.

## How these IAM policies will be used?

When a user will later be added to this team, the right policy will be attached to his role:
 - read-only if 'member'
 - read/write if 'owner' or 'mainteiner'

## Ticket

https://trello.com/c/UZ8qooqO/116-(xl)-create-lambda-functions-to-consume-github-events-from-sns-queues-and-create%2Fupdate%2Fdelete-aws-resources