### PR TITLE
Use python create_user script installed on docker image

### DIFF
--- a/jenkinsfiles/create_user.groovy
+++ b/jenkinsfiles/create_user.groovy
@@ -13,6 +13,6 @@ node {
     }
 
     stage ("Create platform user") {
-        sh "jenkinsfiles/create_user.sh ${env.PLATFORM_ENV} ${env.USERNAME} ${env.EMAIL} \"${env.FULLNAME}\""
+        sh "/usr/local/bin/create_user ${env.USERNAME} ${env.EMAIL} --env ${env.PLATFORM_ENV} --fullname \"${env.FULLNAME}\""
     }
 }


### PR DESCRIPTION
## What

Change create_user Jenkins job to use new python script which checks that user is a member of the moj-analytical-services organization

See [https://trello.com/c/jlT5g9DC](Bugfix: Ensure user is part of analytical services org as part of deployment)