### PR TITLE
Add lambda function to delete team bucket policies

### DIFF
--- a/infra/terraform/modules/data_access/lambda_team_events.tf
+++ b/infra/terraform/modules/data_access/lambda_team_events.tf
@@ -20,8 +20,7 @@ resource "aws_lambda_function" "team_events" {
         variables = {
             LAMBDA_CREATE_TEAM_BUCKET_ARN = "${aws_lambda_function.create_team_bucket.arn}",
             LAMBDA_CREATE_TEAM_BUCKET_POLICIES_ARN = "${aws_lambda_function.create_team_bucket_policies.arn}",
-            # TODO: Change with real ARNs. Fake for now
-            LAMBDA_DELETE_TEAM_BUCKET_POLICIES_ARN = "TODO: fake ARN",
+            LAMBDA_DELETE_TEAM_BUCKET_POLICIES_ARN = "${aws_lambda_function.delete_team_bucket_policies.arn}",
         }
     }
 }
@@ -52,7 +51,6 @@ resource "aws_iam_role" "team_events_role" {
 resource "aws_iam_role_policy" "team_events_role_policy" {
     name = "${var.env}_team_events_role_policy"
     role = "${aws_iam_role.team_events_role.id}"
-# TODO: Add permission to invoke all lambda functions
     policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -65,7 +63,8 @@ resource "aws_iam_role_policy" "team_events_role_policy" {
       ],
       "Resource": [
         "${aws_lambda_function.create_team_bucket.arn}",
-        "${aws_lambda_function.create_team_bucket_policies.arn}"
+        "${aws_lambda_function.create_team_bucket_policies.arn}",
+        "${aws_lambda_function.delete_team_bucket_policies.arn}"
       ]
     },
     {

--- a/infra/terraform/modules/data_access/teams/tests/conftest.py
+++ b/infra/terraform/modules/data_access/teams/tests/conftest.py
@@ -10,7 +10,15 @@ TEST_BUCKET_REGION = "eu-west-1"
 TEST_STAGE = "test"
 TEST_TEAM_SLUG = "justice-league"
 TEST_BUCKET_NAME = "{}-{}".format(TEST_STAGE, TEST_TEAM_SLUG)
+TEST_IAM_ARN_BASE = "arn:aws:iam::1234"
 TEST_BUCKET_ARN = "arn:aws:s3:::{}".format(TEST_BUCKET_NAME)
+TEST_ROLE_NAME = "test-role"
+TEST_GROUP_NAME = "test-group"
+TEST_USER_NAME = "test-user"
+TEST_READONLY_POLICY_ARN = "{}:policy/teams/{}-readonly".format(
+    TEST_IAM_ARN_BASE, TEST_BUCKET_NAME)
+TEST_READWRITE_POLICY_ARN = "{}:policy/teams/{}-readwrite".format(
+    TEST_IAM_ARN_BASE, TEST_BUCKET_NAME)
 TEST_READONLY_POLICY_DOCUMENT = {
     "Version": "2012-10-17",
     "Statement": [
@@ -64,6 +72,7 @@ TEST_READWRITE_POLICY_DOCUMENT["Statement"].append(
 def given_the_env_is_set():
     with mock.patch.dict("os.environ", {
         "BUCKET_REGION": TEST_BUCKET_REGION,
+        "IAM_ARN_BASE": TEST_IAM_ARN_BASE,
         "STAGE": TEST_STAGE,
     }):
         yield
@@ -71,7 +80,18 @@ def given_the_env_is_set():
 
 @pytest.fixture
 def iam_client_mock():
-    return mock.create_autospec(boto3.client("iam"))
+    client = mock.create_autospec(boto3.client("iam"))
+
+    entities_for_policy = {
+        "PolicyRoles": [{"RoleName": TEST_ROLE_NAME}],
+        "PolicyGroups": [{"GroupName": TEST_GROUP_NAME}],
+        "PolicyUsers": [{"UserName": TEST_USER_NAME}],
+    }
+    client.list_entities_for_policy = mock.Mock(
+        return_value=entities_for_policy
+    )
+
+    return client
 
 
 @pytest.fixture

--- a/infra/terraform/modules/data_access/teams/tests/test_delete_team_bucket_policies.py
+++ b/infra/terraform/modules/data_access/teams/tests/test_delete_team_bucket_policies.py
@@ -1,0 +1,77 @@
+import json
+from mock import call
+
+import pytest
+
+import teams
+
+from tests.conftest import (
+    TEST_GROUP_NAME,
+    TEST_READONLY_POLICY_ARN,
+    TEST_READWRITE_POLICY_ARN,
+    TEST_ROLE_NAME,
+    TEST_TEAM_SLUG,
+    TEST_USER_NAME
+)
+
+
+@pytest.mark.usefixtures(
+    "given_the_env_is_set",
+    "given_iam_is_available",
+)
+def test_when_the_team_is_deleted_the_bucket_policies_are_detached_from_everything(iam_client_mock):
+    teams.delete_team_bucket_policies({"team": {"slug": TEST_TEAM_SLUG}}, None)
+
+    # Policies detached from from roles
+    calls = [
+        call(
+            RoleName=TEST_ROLE_NAME,
+            PolicyArn=TEST_READONLY_POLICY_ARN,
+        ),
+        call(
+            RoleName=TEST_ROLE_NAME,
+            PolicyArn=TEST_READWRITE_POLICY_ARN,
+        ),
+    ]
+    iam_client_mock.detach_role_policy.assert_has_calls(calls)
+
+    # Policies detached from groups
+    calls = [
+        call(
+            GroupName=TEST_GROUP_NAME,
+            PolicyArn=TEST_READONLY_POLICY_ARN,
+        ),
+        call(
+            GroupName=TEST_GROUP_NAME,
+            PolicyArn=TEST_READWRITE_POLICY_ARN,
+        ),
+    ]
+    iam_client_mock.detach_group_policy.assert_has_calls(calls)
+
+    # Policies detached from users
+    calls = [
+        call(
+            UserName=TEST_USER_NAME,
+            PolicyArn=TEST_READONLY_POLICY_ARN,
+        ),
+        call(
+            UserName=TEST_USER_NAME,
+            PolicyArn=TEST_READWRITE_POLICY_ARN,
+        ),
+    ]
+    iam_client_mock.detach_user_policy.assert_has_calls(calls)
+
+
+@pytest.mark.usefixtures(
+    "given_the_env_is_set",
+    "given_iam_is_available",
+)
+def test_when_the_team_is_deleted_the_bucket_policies_are_deleted(iam_client_mock):
+    teams.delete_team_bucket_policies({"team": {"slug": TEST_TEAM_SLUG}}, None)
+
+    calls = [
+        call(PolicyArn=TEST_READONLY_POLICY_ARN),
+        call(PolicyArn=TEST_READWRITE_POLICY_ARN),
+    ]
+
+    iam_client_mock.delete_policy.assert_has_calls(calls)


### PR DESCRIPTION
## What

When a team is deleted in GitHub we want the corresponding S3 bucket
policies to be deleted, but not the bucket itself which may still
contain important data.

Delete a policy is not as straightforward as it sounds unfortunately
because it needs to be detached from roles, groups and users first
([See AWS documentation](https://docs.aws.amazon.com/de_de/IAM/latest/APIReference/API_DeletePolicy.html))

## Ticket

https://trello.com/c/UZ8qooqO/116-(xl)-create-lambda-functions-to-consume-github-events-from-sns-queues-and-create%2Fupdate%2Fdelete-aws-resources