### PR TITLE
SAML integration

### DIFF
--- a/infra/terraform/environments/dev/main.tf
+++ b/infra/terraform/environments/dev/main.tf
@@ -126,6 +126,8 @@ module "data_access" {
     env = "${var.env}"
     account_id = "${data.aws_caller_identity.current.account_id}"
 
+    saml_provider_arn = "${module.federated_identity.saml_provider_arn}"
+
     organization_events_topic_arn = "${module.notifications.organization_events_topic_arn}"
     team_events_topic_arn = "${module.notifications.team_events_topic_arn}"
 }

--- a/infra/terraform/modules/data_access/inputs.tf
+++ b/infra/terraform/modules/data_access/inputs.tf
@@ -2,5 +2,7 @@ variable "region" {}
 variable "account_id" {}
 variable "env" {}
 
+variable "saml_provider_arn" {}
+
 variable "organization_events_topic_arn" {}
 variable "team_events_topic_arn" {}

--- a/infra/terraform/modules/data_access/lambda_users.tf
+++ b/infra/terraform/modules/data_access/lambda_users.tf
@@ -19,7 +19,7 @@ resource "aws_lambda_function" "create_user_role" {
     environment {
         variables = {
             STAGE = "${var.env}",
-            SAML_PROVIDER_ARN = "arn:aws:iam::${var.account_id}:saml-provider/auth0",
+            SAML_PROVIDER_ARN = "${var.saml_provider_arn}",
         }
     }
 }

--- a/infra/terraform/modules/data_access/users/tests/conftest.py
+++ b/infra/terraform/modules/data_access/users/tests/conftest.py
@@ -8,7 +8,7 @@ import pytest
 TEST_SAML_PROVIDER_ARN = "arn:aws:iam::123456789012:saml-provider/auth0"
 TEST_STAGE = "test"
 TEST_USERNAME = "alice"
-TEST_ROLE_NAME = "{}_{}_role".format(TEST_STAGE, TEST_USERNAME)
+TEST_ROLE_NAME = "{}_{}".format(TEST_STAGE, TEST_USERNAME)
 
 TEST_ROLE_POLICY_ARN = "test_policy_arn"
 

--- a/infra/terraform/modules/data_access/users/users.py
+++ b/infra/terraform/modules/data_access/users/users.py
@@ -69,7 +69,7 @@ def detach_role_policies(role_name):
 
 
 def role_name(username):
-    return "{env}_{username}_role".format(
+    return "{env}_{username}".format(
         env=os.environ["STAGE"],
         username=username,
     )


### PR DESCRIPTION
## What

Updated code to:
1. `data_access` module use `saml_provider_arn` output variable from `federated_identity` module instead of hardcoding the SAML provider ARN
2. Removed `_role` suffix from generated roles to adhere with [Auth0 rule](https://github.com/ministryofjustice/analytics-platform-auth0/blob/dev/rules/aws-saml-role-mapping.js#L3-L17) used to generate role assumed on login.




## Related PR

[Adds AWS Auth0 identity provider](https://github.com/ministryofjustice/analytics-platform-ops/pull/69)