### PR TITLE
Add lambda function to handle GitHub membership events

### DIFF
--- a/infra/terraform/environments/dev/main.tf
+++ b/infra/terraform/environments/dev/main.tf
@@ -128,6 +128,7 @@ module "data_access" {
 
     saml_provider_arn = "${module.federated_identity.saml_provider_arn}"
 
+    membership_events_topic_arn = "${module.notifications.membership_events_topic_arn}"
     organization_events_topic_arn = "${module.notifications.organization_events_topic_arn}"
     team_events_topic_arn = "${module.notifications.team_events_topic_arn}"
 }

--- a/infra/terraform/modules/data_access/inputs.tf
+++ b/infra/terraform/modules/data_access/inputs.tf
@@ -4,5 +4,6 @@ variable "env" {}
 
 variable "saml_provider_arn" {}
 
+variable "membership_events_topic_arn" {}
 variable "organization_events_topic_arn" {}
 variable "team_events_topic_arn" {}

--- a/infra/terraform/modules/data_access/lambda_membership_events.tf
+++ b/infra/terraform/modules/data_access/lambda_membership_events.tf
@@ -1,0 +1,88 @@
+# Zip the lambda function before the actual deploy
+data "archive_file" "membership_events_zip" {
+    type        = "zip"
+    source_dir  = "${path.module}/membership_events"
+    output_path = "/tmp/membership_events.zip"
+}
+
+# Lambda function which handles GH membership events
+resource "aws_lambda_function" "membership_events" {
+    description = "Updates IAM resources in response to GH membership events"
+    filename = "/tmp/membership_events.zip"
+    source_code_hash = "${data.archive_file.membership_events_zip.output_base64sha256}"
+    function_name = "${var.env}_membership_events"
+    role = "${aws_iam_role.membership_events_role.arn}"
+    handler = "membership_events.event_received"
+    runtime = "python3.6"
+    timeout = 10
+    depends_on = ["data.archive_file.membership_events_zip"]
+    environment {
+        variables = {
+            # TODO: Replace with actual lambda functions ARN
+            LAMBDA_ATTACH_BUCKET_POLICY_ARN = "TODO: attach_bucket_policy.arn",
+            LAMBDA_DETACH_BUCKET_POLICY_ARN = "TODO: detach_bucket_policy.arn",
+            # LAMBDA_ATTACH_BUCKET_POLICY_ARN = "${aws_lambda_function.attach_bucket_policy.arn}",
+            # LAMBDA_DETACH_BUCKET_POLICY_ARN = "${aws_lambda_function.detach_bucket_policy.arn}",
+        }
+    }
+}
+
+# Lambda function triggered by SNS notification
+resource "aws_sns_topic_subscription" "membership_events" {
+    topic_arn = "${var.membership_events_topic_arn}"
+    protocol = "lambda"
+    endpoint = "${aws_lambda_function.membership_events.arn}"
+}
+
+# Permission to invoke the lambda function
+resource "aws_lambda_permission" "allow_membership_events_invocation" {
+    statement_id = "AllowExecutionFromSNS"
+    action = "lambda:InvokeFunction"
+    function_name = "${aws_lambda_function.membership_events.arn}"
+    principal = "sns.amazonaws.com"
+    source_arn = "${var.membership_events_topic_arn}"
+}
+
+# Role running the lambda function
+resource "aws_iam_role" "membership_events_role" {
+    name = "${var.env}_membership_events_role"
+    assume_role_policy = "${data.aws_iam_policy_document.lambda_assume_role.json}"
+}
+
+# Policies for the 'membership_events_role' role
+resource "aws_iam_role_policy" "membership_events_role_policy" {
+    name = "${var.env}_membership_events_role_policy"
+    role = "${aws_iam_role.membership_events_role.id}"
+# TODO: Replace with actual lambda functions ARN
+    # {
+    #   "Sid": "CanInvokeLambdaFunctions",
+    #   "Effect": "Allow",
+    #   "Action": [
+    #     "lambda:InvokeFunction"
+    #   ],
+    #   "Resource": [
+    #     "${aws_lambda_function.attach_bucket_policy.arn}",
+    #     "${aws_lambda_function.detach_bucket_policy.arn}"
+    #   ]
+    # },
+    policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "CanLog",
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents",
+        "logs:DescribeLogStreams"
+      ],
+      "Resource": [
+        "arn:aws:logs:*:*:*"
+      ]
+    }
+  ]
+}
+EOF
+}

--- a/infra/terraform/modules/data_access/membership_events/membership_events.py
+++ b/infra/terraform/modules/data_access/membership_events/membership_events.py
@@ -1,0 +1,63 @@
+'''
+Environment variables:
+ - LAMBDA_ATTACH_BUCKET_POLICY_ARN, ARN of the lambda function to attach the
+   IAM policy for the bucket to the IAM role
+ - LAMBDA_DETACH_BUCKET_POLICY_ARN, ARN of the lambda function to detach the
+   IAM policy for the bucket to the IAM role
+ - LOG_LEVEL, change the logging level (default is "DEBUG"). Must be one of
+   the python logging supported levels: "CRITICAL", "ERROR", "WARNING",
+   "INFO" or "DEBUG" (See: https://docs.python.org/2/library/logging.html#logging-levels)
+'''
+
+import json
+import logging
+import os
+
+import boto3
+
+
+POLICY_READ_WRITE = "readwrite"
+
+
+LOG = logging.getLogger(__name__)
+LOG_LEVEL = os.environ.get("LOG_LEVEL", "DEBUG")
+LOG.setLevel(LOG_LEVEL)
+
+
+# "membership" webhook event: https://developer.github.com/v3/activity/events/types/#membershipevent
+def event_received(sns_event, context):
+    EVENT_HANDLERS = {
+        "added": os.environ["LAMBDA_ATTACH_BUCKET_POLICY_ARN"],
+        "removed": os.environ["LAMBDA_DETACH_BUCKET_POLICY_ARN"],
+    }
+
+    LOG.debug("SNS event received = {}".format(json.dumps(sns_event)))
+    for record in sns_event["Records"]:
+        event = json.loads(record["Sns"]["Message"])
+        action = event["action"]
+
+        if event["scope"] != "team":
+            continue
+
+        if action in EVENT_HANDLERS:
+            invoke_lambda(
+                function=EVENT_HANDLERS[action],
+                payload=payload(event),
+            )
+
+
+def invoke_lambda(function, payload):
+    client = boto3.client("lambda")
+    client.invoke(
+        FunctionName=function,
+        Payload=json.dumps(payload).encode("utf8"),
+        InvocationType="Event",
+    )
+
+
+def payload(event):
+    return {
+        "user": {"username": event["member"]["login"]},
+        "team": {"slug": event["team"]["slug"]},
+        "policy": {"type": POLICY_READ_WRITE},
+    }

--- a/infra/terraform/modules/data_access/membership_events/tests/conftest.py
+++ b/infra/terraform/modules/data_access/membership_events/tests/conftest.py
@@ -1,0 +1,61 @@
+import json
+import mock
+
+import boto3
+import pytest
+
+
+TEST_ATTACH_BUCKET_POLICY_ARN = "arn:aws:iam::123456789012:lambda/attach_bucket_policy"
+TEST_DETACH_BUCKET_POLICY_ARN = "arn:aws:iam::123456789012:lambda/detach_bucket_policy"
+TEST_USERNAME = "alice"
+TEST_TEAM_SLUG = "justice-league"
+
+TEST_PAYLOAD = {
+    "user": {"username": TEST_USERNAME},
+    "team": {"slug": TEST_TEAM_SLUG},
+    "policy": {"type": "readwrite"},
+}
+TEST_PAYLOAD_BYTES = json.dumps(TEST_PAYLOAD).encode("utf8")
+
+
+@pytest.yield_fixture
+def given_the_env_is_set():
+    with mock.patch.dict("os.environ", {
+        "LAMBDA_ATTACH_BUCKET_POLICY_ARN": TEST_ATTACH_BUCKET_POLICY_ARN,
+        "LAMBDA_DETACH_BUCKET_POLICY_ARN": TEST_DETACH_BUCKET_POLICY_ARN,
+    }):
+        yield
+
+
+@pytest.fixture
+def lambda_client_mock():
+    return mock.create_autospec(boto3.client("lambda"))
+
+
+@pytest.yield_fixture
+def given_lambda_is_available(lambda_client_mock):
+    with mock.patch.object(boto3, "client", return_value=lambda_client_mock):
+        yield
+
+
+def sns_event(action):
+    github_event = {
+        "scope": "team",
+        "action": action,
+        "member": {
+            "login": TEST_USERNAME,
+        },
+        "team": {
+            "slug": TEST_TEAM_SLUG,
+        },
+    }
+
+    return {
+        "Records": [
+            {
+                "Sns": {
+                    "Message": json.dumps(github_event),
+                }
+            }
+        ]
+    }

--- a/infra/terraform/modules/data_access/membership_events/tests/test_membership_events.py
+++ b/infra/terraform/modules/data_access/membership_events/tests/test_membership_events.py
@@ -1,0 +1,46 @@
+import boto3
+from botocore.exceptions import ClientError
+import pytest
+
+import membership_events
+
+
+from tests.conftest import (
+    sns_event,
+    TEST_ATTACH_BUCKET_POLICY_ARN,
+    TEST_DETACH_BUCKET_POLICY_ARN,
+    TEST_PAYLOAD_BYTES
+)
+
+
+@pytest.mark.parametrize("event,lambda_arn", [
+    (sns_event("added"), TEST_ATTACH_BUCKET_POLICY_ARN),
+    (sns_event("removed"), TEST_DETACH_BUCKET_POLICY_ARN)
+])
+@pytest.mark.usefixtures(
+    "given_the_env_is_set",
+    "given_lambda_is_available",
+)
+def test_when_event_received_is_handled(lambda_client_mock, event, lambda_arn):
+    membership_events.event_received(event, None)
+
+    # Test right lambda function is invoked asyncronously
+    lambda_client_mock.invoke.assert_called_with(
+        FunctionName=lambda_arn,
+        Payload=TEST_PAYLOAD_BYTES,
+        InvocationType="Event",
+    )
+
+
+@pytest.mark.usefixtures(
+    "given_the_env_is_set",
+    "given_lambda_is_available",
+)
+def test_when_event_scope_not_team_event_is_ignored(lambda_client_mock):
+    event = sns_event("some_action")
+    event["scope"] = "other_scope"
+
+    membership_events.event_received(event, None)
+
+    # No lambda function is invoked
+    lambda_client_mock.invoke.assert_not_called()


### PR DESCRIPTION
Handles events coming from GitHub/membership SNS topic.

These are published when a user is added/removed to/from a team in
GitHub:
 - If a user is added to a group, we attach the corresponding bucket policy
   to this user's role
 - If a user is removed to a group, we detach the corresponding bucket policy
   from this user's role

These two operations are actually performed by two independent lambda
functions injected via the `LAMBDA_ATTACH_BUCKET_POLICY_ARN` and
`LAMBDA_DETACH_BUCKET_POLICY_ARN` environment variables.

**NOTE**: These lambda functions currently don't exist and I'll update the
terraform resources later to pass the actual ARNs. This shouldn't change
the logic.


## Limitations

Surprising GitHub webhook membership events payload don't include the user
role for the team where is added. And also, no events are published when
a user's role changes.

This means we don't have a way to tell if a user is just a "member",
"maintainer" or "owner" in a team or when its level changes.

For simplicity we'll add the read/write policy to the user.
When/if we'll have a UI to handle permissions we can add extra logic to
attach a readonly policy when more appropriare.

## Resources

* [Ticket](https://trello.com/c/UZ8qooqO/116-xl-create-lambda-functions-to-consume-github-events-from-sns-queues-and-create-update-delete-aws-resources)
* ["membership" webhook event GitHub documentation](https://developer.github.com/v3/activity/events/types/#membershipevent)
