### PR TITLE
Add lambda functions to attach/detach IAM policies to/from IAM roles

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,6 @@
+machine:
+  python:
+    version: 3.6.1
+test:
+  override:
+    - infra/terraform/modules/data_access/test.sh

--- a/infra/terraform/environments/alpha/main.tf
+++ b/infra/terraform/environments/alpha/main.tf
@@ -120,6 +120,20 @@ module "notifications" {
     gh_hook_secret = "${var.gh_hook_secret}"
 }
 
+module "data_access" {
+    source = "../../modules/data_access"
+
+    region = "${var.region}"
+    env = "${var.env}"
+    account_id = "${data.aws_caller_identity.current.account_id}"
+
+    saml_provider_arn = "${module.federated_identity.saml_provider_arn}"
+
+    membership_events_topic_arn = "${module.notifications.membership_events_topic_arn}"
+    organization_events_topic_arn = "${module.notifications.organization_events_topic_arn}"
+    team_events_topic_arn = "${module.notifications.team_events_topic_arn}"
+}
+
 module "federated_identity" {
     source ="../../modules/federated_identity"
     env = "${var.env}"

--- a/infra/terraform/environments/alpha/main.tf
+++ b/infra/terraform/environments/alpha/main.tf
@@ -128,6 +128,7 @@ module "data_access" {
     account_id = "${data.aws_caller_identity.current.account_id}"
 
     saml_provider_arn = "${module.federated_identity.saml_provider_arn}"
+    k8s_worker_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/nodes.${var.env}.${data.terraform_remote_state.base.xyz_root_domain}"
 
     membership_events_topic_arn = "${module.notifications.membership_events_topic_arn}"
     organization_events_topic_arn = "${module.notifications.organization_events_topic_arn}"

--- a/infra/terraform/modules/data_access/lambda_membership_events.tf
+++ b/infra/terraform/modules/data_access/lambda_membership_events.tf
@@ -18,10 +18,9 @@ resource "aws_lambda_function" "membership_events" {
     depends_on = ["data.archive_file.membership_events_zip"]
     environment {
         variables = {
-            # TODO: Replace with actual lambda functions ARN
-            LAMBDA_ATTACH_BUCKET_POLICY_ARN = "TODO: attach_bucket_policy.arn",
+            LAMBDA_ATTACH_BUCKET_POLICY_ARN = "${aws_lambda_function.attach_bucket_policy.arn}",
+            # TODO: Replace with actual lambda function ARN
             LAMBDA_DETACH_BUCKET_POLICY_ARN = "TODO: detach_bucket_policy.arn",
-            # LAMBDA_ATTACH_BUCKET_POLICY_ARN = "${aws_lambda_function.attach_bucket_policy.arn}",
             # LAMBDA_DETACH_BUCKET_POLICY_ARN = "${aws_lambda_function.detach_bucket_policy.arn}",
         }
     }
@@ -53,22 +52,21 @@ resource "aws_iam_role" "membership_events_role" {
 resource "aws_iam_role_policy" "membership_events_role_policy" {
     name = "${var.env}_membership_events_role_policy"
     role = "${aws_iam_role.membership_events_role.id}"
-# TODO: Replace with actual lambda functions ARN
-    # {
-    #   "Sid": "CanInvokeLambdaFunctions",
-    #   "Effect": "Allow",
-    #   "Action": [
-    #     "lambda:InvokeFunction"
-    #   ],
-    #   "Resource": [
-    #     "${aws_lambda_function.attach_bucket_policy.arn}",
-    #     "${aws_lambda_function.detach_bucket_policy.arn}"
-    #   ]
-    # },
+# TODO: Add 'aws_lambda_function.detach_bucket_policy.arn'
     policy = <<EOF
 {
   "Version": "2012-10-17",
   "Statement": [
+    {
+      "Sid": "CanInvokeLambdaFunctions",
+      "Effect": "Allow",
+      "Action": [
+        "lambda:InvokeFunction"
+      ],
+      "Resource": [
+        "${aws_lambda_function.attach_bucket_policy.arn}"
+      ]
+    },
     {
       "Sid": "CanLog",
       "Effect": "Allow",

--- a/infra/terraform/modules/data_access/lambda_membership_events.tf
+++ b/infra/terraform/modules/data_access/lambda_membership_events.tf
@@ -19,9 +19,7 @@ resource "aws_lambda_function" "membership_events" {
     environment {
         variables = {
             LAMBDA_ATTACH_BUCKET_POLICY_ARN = "${aws_lambda_function.attach_bucket_policy.arn}",
-            # TODO: Replace with actual lambda function ARN
-            LAMBDA_DETACH_BUCKET_POLICY_ARN = "TODO: detach_bucket_policy.arn",
-            # LAMBDA_DETACH_BUCKET_POLICY_ARN = "${aws_lambda_function.detach_bucket_policy.arn}",
+            LAMBDA_DETACH_BUCKET_POLICIES_ARN = "${aws_lambda_function.detach_bucket_policies.arn}",
         }
     }
 }
@@ -52,7 +50,6 @@ resource "aws_iam_role" "membership_events_role" {
 resource "aws_iam_role_policy" "membership_events_role_policy" {
     name = "${var.env}_membership_events_role_policy"
     role = "${aws_iam_role.membership_events_role.id}"
-# TODO: Add 'aws_lambda_function.detach_bucket_policy.arn'
     policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -64,7 +61,8 @@ resource "aws_iam_role_policy" "membership_events_role_policy" {
         "lambda:InvokeFunction"
       ],
       "Resource": [
-        "${aws_lambda_function.attach_bucket_policy.arn}"
+        "${aws_lambda_function.attach_bucket_policy.arn}",
+        "${aws_lambda_function.detach_bucket_policies.arn}"
       ]
     },
     {

--- a/infra/terraform/modules/data_access/lambda_memberships.tf
+++ b/infra/terraform/modules/data_access/lambda_memberships.tf
@@ -1,0 +1,67 @@
+# Zip the lambda function before the actual deploy
+data "archive_file" "memberships_zip" {
+    type        = "zip"
+    source_dir  = "${path.module}/memberships"
+    output_path = "/tmp/memberships.zip"
+}
+
+# Lambda function to attach bucket IAM policy to IAM role
+resource "aws_lambda_function" "attach_bucket_policy" {
+    description = "Attaches bucket IAM policy to IAM role"
+    filename = "/tmp/memberships.zip"
+    source_code_hash = "${data.archive_file.memberships_zip.output_base64sha256}"
+    function_name = "${var.env}_attach_bucket_policy"
+    role = "${aws_iam_role.attach_bucket_policy.arn}"
+    handler = "memberships.attach_bucket_policy"
+    runtime = "python3.6"
+    timeout = 10
+    depends_on = ["data.archive_file.memberships_zip"]
+    environment {
+        variables = {
+            STAGE = "${var.env}",
+            IAM_ARN_BASE = "arn:aws:iam::${var.account_id}"
+        }
+    }
+}
+
+# Role assumed by the 'attach_bucket_policy' lambda function
+resource "aws_iam_role" "attach_bucket_policy" {
+    name = "${var.env}_attach_bucket_policy"
+    assume_role_policy = "${data.aws_iam_policy_document.lambda_assume_role.json}"
+}
+
+# Policies for the 'attach_bucket_policy' role
+resource "aws_iam_role_policy" "attach_bucket_policy" {
+    name = "${var.env}_attach_bucket_policy"
+    role = "${aws_iam_role.attach_bucket_policy.id}"
+    policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "CanAttachPolicy",
+      "Effect": "Allow",
+      "Action": [
+        "iam:AttachRolePolicy"
+      ],
+      "Resource": [
+        "arn:aws:iam::${var.account_id}:role/users/${var.env}_*"
+      ]
+    },
+    {
+      "Sid": "CanLog",
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents",
+        "logs:DescribeLogStreams"
+      ],
+      "Resource": [
+        "arn:aws:logs:*:*:*"
+      ]
+    }
+  ]
+}
+EOF
+}

--- a/infra/terraform/modules/data_access/membership_events/tests/conftest.py
+++ b/infra/terraform/modules/data_access/membership_events/tests/conftest.py
@@ -6,23 +6,28 @@ import pytest
 
 
 TEST_ATTACH_BUCKET_POLICY_ARN = "arn:aws:iam::123456789012:lambda/attach_bucket_policy"
-TEST_DETACH_BUCKET_POLICY_ARN = "arn:aws:iam::123456789012:lambda/detach_bucket_policy"
+TEST_DETACH_BUCKET_POLICIES_ARN = "arn:aws:iam::123456789012:lambda/detach_bucket_policies"
 TEST_USERNAME = "alice"
 TEST_TEAM_SLUG = "justice-league"
 
-TEST_PAYLOAD = {
+TEST_ATTACH_PAYLOAD = {
     "user": {"username": TEST_USERNAME},
     "team": {"slug": TEST_TEAM_SLUG},
     "policy": {"type": "readwrite"},
 }
-TEST_PAYLOAD_BYTES = json.dumps(TEST_PAYLOAD).encode("utf8")
+TEST_ATTACH_PAYLOAD_BYTES = json.dumps(TEST_ATTACH_PAYLOAD).encode("utf8")
 
+TEST_DETACH_PAYLOAD = {
+    "user": {"username": TEST_USERNAME},
+    "team": {"slug": TEST_TEAM_SLUG},
+}
+TEST_DETACH_PAYLOAD_BYTES = json.dumps(TEST_DETACH_PAYLOAD).encode("utf8")
 
 @pytest.yield_fixture
 def given_the_env_is_set():
     with mock.patch.dict("os.environ", {
         "LAMBDA_ATTACH_BUCKET_POLICY_ARN": TEST_ATTACH_BUCKET_POLICY_ARN,
-        "LAMBDA_DETACH_BUCKET_POLICY_ARN": TEST_DETACH_BUCKET_POLICY_ARN,
+        "LAMBDA_DETACH_BUCKET_POLICIES_ARN": TEST_DETACH_BUCKET_POLICIES_ARN,
     }):
         yield
 

--- a/infra/terraform/modules/data_access/memberships/memberships.py
+++ b/infra/terraform/modules/data_access/memberships/memberships.py
@@ -1,0 +1,71 @@
+
+'''
+Environment variables:
+ - STAGE, e.g. "dev", "alpha", etc...
+ - IAM_ARN_BASE, e.g. "arn:aws:iam::1234"
+'''
+
+
+import json
+import os
+
+import boto3
+
+
+POLICY_READ_ONLY = "readonly"
+POLICY_READ_WRITE = "readwrite"
+
+
+class InvalidPolicyType(Exception):
+    pass
+
+
+def attach_bucket_policy(event, context):
+    """
+    Attaches the team bucket IAM policy to the user's IAM role
+
+    event = {
+        "user": {"username": "alice"},
+        "team": {"slug": "justice-league"},
+        "policy": {"type": "readwrite"},
+    }
+    """
+    policy_type = event["policy"]["type"]
+    if not policy_type in [POLICY_READ_ONLY, POLICY_READ_WRITE]:
+        raise InvalidPolicyType("type can only be '{}' or '{}'".format(
+            POLICY_READ_ONLY, POLICY_READ_WRITE))
+
+    username = event["user"]["username"]
+    team_slug = event["team"]["slug"]
+
+    client = boto3.client("iam")
+    client.attach_role_policy(
+        RoleName=role_name(username),
+        PolicyArn=policy_arn(team_slug, policy_type),
+    )
+
+
+def role_name(username):
+    return "{env}_{username}".format(
+        env=os.environ["STAGE"],
+        username=username,
+    )
+
+
+def policy_arn(team_slug, policy_type):
+    policy_name = "{bucket_name}-{policy_type}".format(
+        bucket_name=bucket_name(team_slug),
+        policy_type=policy_type,
+    )
+
+    return "{iam_arn_base}:policy/teams/{policy_name}".format(
+        iam_arn_base=os.environ["IAM_ARN_BASE"],
+        policy_name=policy_name,
+    )
+
+
+def bucket_name(team_slug):
+    return "{env}-{team_slug}".format(
+        env=os.environ["STAGE"],
+        team_slug=team_slug
+    )

--- a/infra/terraform/modules/data_access/memberships/memberships.py
+++ b/infra/terraform/modules/data_access/memberships/memberships.py
@@ -97,7 +97,7 @@ def validate_policy_type(policy_type):
 def role_name(username):
     return "{env}_{username}".format(
         env=os.environ["STAGE"],
-        username=username,
+        username=username.lower(),
     )
 
 
@@ -116,5 +116,5 @@ def policy_arn(team_slug, policy_type):
 def bucket_name(team_slug):
     return "{env}-{team_slug}".format(
         env=os.environ["STAGE"],
-        team_slug=team_slug
+        team_slug=team_slug.lower()
     )

--- a/infra/terraform/modules/data_access/memberships/tests/conftest.py
+++ b/infra/terraform/modules/data_access/memberships/tests/conftest.py
@@ -7,11 +7,11 @@ import pytest
 
 TEST_IAM_ARN_BASE = "arn:aws:iam::1234"
 TEST_STAGE = "test"
-TEST_TEAM_SLUG = "justice-league"
-TEST_USERNAME = "alice"
+TEST_TEAM_SLUG = "Justice-League"
+TEST_USERNAME = "Alice"
 
-TEST_BUCKET_NAME = "{}-{}".format(TEST_STAGE, TEST_TEAM_SLUG)
-TEST_ROLE_NAME = "{}_{}".format(TEST_STAGE, TEST_USERNAME)
+TEST_BUCKET_NAME = "{}-{}".format(TEST_STAGE, TEST_TEAM_SLUG.lower())
+TEST_ROLE_NAME = "{}_{}".format(TEST_STAGE, TEST_USERNAME.lower())
 TEST_POLICY_ARN_PREFIX = "{iam_arn_base}:policy/teams/{bucket_name}".format(
     iam_arn_base=TEST_IAM_ARN_BASE,
     bucket_name=TEST_BUCKET_NAME,

--- a/infra/terraform/modules/data_access/memberships/tests/conftest.py
+++ b/infra/terraform/modules/data_access/memberships/tests/conftest.py
@@ -1,0 +1,40 @@
+import json
+import mock
+
+import boto3
+import pytest
+
+
+TEST_IAM_ARN_BASE = "arn:aws:iam::1234"
+TEST_STAGE = "test"
+TEST_TEAM_SLUG = "justice-league"
+TEST_USERNAME = "alice"
+
+TEST_BUCKET_NAME = "{}-{}".format(TEST_STAGE, TEST_TEAM_SLUG)
+TEST_ROLE_NAME = "{}_{}".format(TEST_STAGE, TEST_USERNAME)
+TEST_POLICY_ARN_PREFIX = "{iam_arn_base}:policy/teams/{bucket_name}".format(
+    iam_arn_base=TEST_IAM_ARN_BASE,
+    bucket_name=TEST_BUCKET_NAME,
+)
+TEST_READ_ONLY_POLICY_ARN = "{}-readonly".format(TEST_POLICY_ARN_PREFIX)
+TEST_READ_WRITE_POLICY_ARN = "{}-readwrite".format(TEST_POLICY_ARN_PREFIX)
+
+
+@pytest.yield_fixture
+def given_the_env_is_set():
+    with mock.patch.dict("os.environ", {
+        "STAGE": TEST_STAGE,
+        "IAM_ARN_BASE": TEST_IAM_ARN_BASE,
+    }):
+        yield
+
+
+@pytest.fixture
+def iam_client_mock():
+    return mock.create_autospec(boto3.client("iam"))
+
+
+@pytest.yield_fixture
+def given_iam_is_available(iam_client_mock):
+    with mock.patch.object(boto3, "client", return_value=iam_client_mock):
+        yield

--- a/infra/terraform/modules/data_access/memberships/tests/test_attach_bucket_policy.py
+++ b/infra/terraform/modules/data_access/memberships/tests/test_attach_bucket_policy.py
@@ -1,0 +1,61 @@
+import json
+
+import pytest
+
+import memberships
+
+from tests.conftest import (
+    TEST_READ_ONLY_POLICY_ARN,
+    TEST_READ_WRITE_POLICY_ARN,
+    TEST_ROLE_NAME,
+    TEST_TEAM_SLUG,
+    TEST_USERNAME,
+)
+
+
+@pytest.mark.usefixtures(
+    "given_the_env_is_set",
+    "given_iam_is_available",
+)
+def test_when_policy_type_is_invalid_raise_exception():
+    event = {
+        "policy": {"type": "Invalid!"},
+    }
+    with pytest.raises(memberships.InvalidPolicyType):
+        memberships.attach_bucket_policy(event, None)
+
+
+@pytest.mark.usefixtures(
+    "given_the_env_is_set",
+    "given_iam_is_available",
+)
+def test_when_policy_type_reaonly_attaches_it_to_right_role(iam_client_mock):
+    event = {
+        "policy": {"type": memberships.POLICY_READ_ONLY},
+        "user": {"username": TEST_USERNAME},
+        "team": {"slug": TEST_TEAM_SLUG},
+    }
+    memberships.attach_bucket_policy(event, None)
+
+    iam_client_mock.attach_role_policy.assert_called_with(
+        PolicyArn=TEST_READ_ONLY_POLICY_ARN,
+        RoleName=TEST_ROLE_NAME,
+    )
+
+
+@pytest.mark.usefixtures(
+    "given_the_env_is_set",
+    "given_iam_is_available",
+)
+def test_when_policy_type_reawrite_attaches_it_to_right_role(iam_client_mock):
+    event = {
+        "policy": {"type": memberships.POLICY_READ_WRITE},
+        "user": {"username": TEST_USERNAME},
+        "team": {"slug": TEST_TEAM_SLUG},
+    }
+    memberships.attach_bucket_policy(event, None)
+
+    iam_client_mock.attach_role_policy.assert_called_with(
+        PolicyArn=TEST_READ_WRITE_POLICY_ARN,
+        RoleName=TEST_ROLE_NAME,
+    )

--- a/infra/terraform/modules/data_access/memberships/tests/test_detach_bucket_policies.py
+++ b/infra/terraform/modules/data_access/memberships/tests/test_detach_bucket_policies.py
@@ -1,0 +1,58 @@
+import json
+from mock import call
+
+import botocore.exceptions
+import pytest
+
+import memberships
+
+from tests.conftest import (
+    TEST_READ_ONLY_POLICY_ARN,
+    TEST_READ_WRITE_POLICY_ARN,
+    TEST_ROLE_NAME,
+    TEST_TEAM_SLUG,
+    TEST_USERNAME,
+)
+
+
+def raise_detach_role_policy_exception(**kwarg):
+    raise botocore.exceptions.ClientError(
+        {
+            "Error": {
+                "Code": "NoSuchEntity",
+                "Message": "Policy arn:... was not found.",
+            }
+        },
+        "DetachRolePolicy"
+    )
+
+
+@pytest.mark.usefixtures(
+    "given_the_env_is_set",
+    "given_iam_is_available",
+)
+def test_when_invoked_detaches_all_bucket_policies_from_the_role(iam_client_mock):
+    # This is to test the scenario when 1+ of the policies tried to be
+    # detached is not actually attached: In this case we still boto/AWS will
+    # raise an exception but we still want to carry on and detach the rest
+    # of the policies.
+    iam_client_mock.detach_role_policy.side_effect = raise_detach_role_policy_exception
+
+    event = {
+        "user": {"username": TEST_USERNAME},
+        "team": {"slug": TEST_TEAM_SLUG},
+    }
+    memberships.detach_bucket_policies(event, None)
+
+    calls = [
+        call(
+            PolicyArn=TEST_READ_WRITE_POLICY_ARN,
+            RoleName=TEST_ROLE_NAME,
+        ),
+        call(
+            PolicyArn=TEST_READ_ONLY_POLICY_ARN,
+            RoleName=TEST_ROLE_NAME,
+        ),
+    ]
+
+    iam_client_mock.detach_role_policy.assert_has_calls(calls)

--- a/infra/terraform/modules/data_access/memberships/tests/test_detach_bucket_policies.py
+++ b/infra/terraform/modules/data_access/memberships/tests/test_detach_bucket_policies.py
@@ -32,10 +32,13 @@ def raise_detach_role_policy_exception(**kwarg):
     "given_iam_is_available",
 )
 def test_when_invoked_detaches_all_bucket_policies_from_the_role(iam_client_mock):
-    # This is to test the scenario when 1+ of the policies tried to be
-    # detached is not actually attached: In this case we still boto/AWS will
-    # raise an exception but we still want to carry on and detach the rest
-    # of the policies.
+    '''
+    This is to test the scenario when 1+ of the policies tried to be
+    detached is not actually attached: In this case boto/AWS will still
+    raise an exception but we still want to carry on and detach the rest of
+    the policies.
+    '''
+
     iam_client_mock.detach_role_policy.side_effect = raise_detach_role_policy_exception
 
     event = {

--- a/infra/terraform/modules/data_access/organization_events/tests/test_organization_events.py
+++ b/infra/terraform/modules/data_access/organization_events/tests/test_organization_events.py
@@ -1,5 +1,4 @@
 import boto3
-from botocore.exceptions import ClientError
 import pytest
 
 import organization_events

--- a/infra/terraform/modules/data_access/team_events/tests/test_team_events.py
+++ b/infra/terraform/modules/data_access/team_events/tests/test_team_events.py
@@ -1,7 +1,6 @@
 from mock import call
 
 import boto3
-from botocore.exceptions import ClientError
 import pytest
 
 import team_events

--- a/infra/terraform/modules/data_access/teams/teams.py
+++ b/infra/terraform/modules/data_access/teams/teams.py
@@ -214,4 +214,4 @@ def detach_policy_from_user(policy_arn, user_name):
 
 
 def bucket_name(slug):
-    return "{}-{}".format(os.environ["STAGE"], slug)
+    return "{}-{}".format(os.environ["STAGE"], slug.lower())

--- a/infra/terraform/modules/data_access/teams/tests/conftest.py
+++ b/infra/terraform/modules/data_access/teams/tests/conftest.py
@@ -8,8 +8,8 @@ import pytest
 
 TEST_BUCKET_REGION = "eu-west-1"
 TEST_STAGE = "test"
-TEST_TEAM_SLUG = "justice-league"
-TEST_BUCKET_NAME = "{}-{}".format(TEST_STAGE, TEST_TEAM_SLUG)
+TEST_TEAM_SLUG = "Justice-League"
+TEST_BUCKET_NAME = "{}-{}".format(TEST_STAGE, TEST_TEAM_SLUG.lower())
 TEST_IAM_ARN_BASE = "arn:aws:iam::1234"
 TEST_BUCKET_ARN = "arn:aws:s3:::{}".format(TEST_BUCKET_NAME)
 TEST_ROLE_NAME = "test-role"

--- a/infra/terraform/modules/data_access/test.sh
+++ b/infra/terraform/modules/data_access/test.sh
@@ -1,0 +1,20 @@
+#! /usr/bin/env bash
+set -ex
+
+echo "Setting test environment..."
+BASE_DIR=$(cd $(dirname $0) ; pwd -P)
+cd $BASE_DIR
+python3 -mvenv venv
+source venv/bin/activate
+pip3 install -r requirements.dev.txt
+deactivate
+source venv/bin/activate
+# Required by boto in CI
+export AWS_DEFAULT_REGION=eu-west-1
+
+echo "Running tests..."
+for tests_dir in "membership_events" "memberships" "organization_events" "team_events" "teams" "users";
+do
+  cd "$BASE_DIR/$tests_dir"
+  pytest ./tests --spec
+done

--- a/infra/terraform/modules/data_access/users/tests/conftest.py
+++ b/infra/terraform/modules/data_access/users/tests/conftest.py
@@ -8,8 +8,8 @@ import pytest
 TEST_SAML_PROVIDER_ARN = "arn:aws:iam::123456789012:saml-provider/auth0"
 TEST_K8S_WORKER_ROLE_ARN = "arn:aws:iam::123456789012:role/nodes.test.example.com"
 TEST_STAGE = "test"
-TEST_USERNAME = "alice"
-TEST_ROLE_NAME = "{}_{}".format(TEST_STAGE, TEST_USERNAME)
+TEST_USERNAME = "Alice"
+TEST_ROLE_NAME = "{}_{}".format(TEST_STAGE, TEST_USERNAME.lower())
 
 TEST_ROLE_POLICY_ARN = "test_policy_arn"
 

--- a/infra/terraform/modules/data_access/users/users.py
+++ b/infra/terraform/modules/data_access/users/users.py
@@ -88,5 +88,5 @@ def detach_role_policies(role_name):
 def role_name(username):
     return "{env}_{username}".format(
         env=os.environ["STAGE"],
-        username=username,
+        username=username.lower(),
     )


### PR DESCRIPTION
### `attach_bucket_policy()`

Invoked when a member is added to a team.
Attaches the specified IAM team bucket policy to the corresponding user role (e.g. `readonly` or `readwrite`).


### `detach_bucket_policies()`

Detaches all the IAM team bucket policies (`readonly` and `readwrite`) from the user role.

One subtle thing to notice here is that a given role would probably have only one of the currently available IAM policies (e.g. `readwrite` only). As AWS raises an exception when trying to detach a policy which is not attached, we need to be sure that we handle it and continue to detach all the IAM team bucket policies from the role.


### Ticket:

https://trello.com/c/UZ8qooqO/116-xl-create-lambda-functions-to-consume-github-events-from-sns-queues-and-create-update-delete-aws-resources