### PR TITLE
Set up CircleCI to run tests

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,6 @@
+machine:
+  python:
+    version: 3.6.1
+test:
+  override:
+    - infra/terraform/modules/data_access/test.sh

--- a/infra/terraform/modules/data_access/test.sh
+++ b/infra/terraform/modules/data_access/test.sh
@@ -1,0 +1,25 @@
+#! /usr/bin/env bash
+
+echo "Setting test environment..."
+cd "$(dirname "$0")"
+python3 -mvenv venv
+source venv/bin/activate
+pip3 install -r requirements.dev.txt
+deactivate
+source venv/bin/activate
+
+echo "Running tests..."
+cd membership_events
+pytest ./tests --spec
+
+cd ../memberships
+pytest ./tests --spec
+
+cd ../organization_events
+pytest ./tests --spec
+
+cd ../team_events
+pytest ./tests --spec
+
+cd ../teams
+pytest ./tests --spec


### PR DESCRIPTION
## What

Added a `test.sh` script under `infra/terraform/modules/data_access` to run the `data_access`'s tests.

This script will set up virtualenv and install the dependencies and run the tests.