### PR TITLE
Allow users' IAM roles to be assumed by EC2 instances

### DIFF
--- a/infra/terraform/environments/dev/main.tf
+++ b/infra/terraform/environments/dev/main.tf
@@ -127,6 +127,7 @@ module "data_access" {
     account_id = "${data.aws_caller_identity.current.account_id}"
 
     saml_provider_arn = "${module.federated_identity.saml_provider_arn}"
+    k8s_worker_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/nodes.${var.env}.${data.terraform_remote_state.base.xyz_root_domain}"
 
     membership_events_topic_arn = "${module.notifications.membership_events_topic_arn}"
     organization_events_topic_arn = "${module.notifications.organization_events_topic_arn}"

--- a/infra/terraform/modules/data_access/inputs.tf
+++ b/infra/terraform/modules/data_access/inputs.tf
@@ -3,6 +3,7 @@ variable "account_id" {}
 variable "env" {}
 
 variable "saml_provider_arn" {}
+variable "k8s_worker_role_arn" {}
 
 variable "membership_events_topic_arn" {}
 variable "organization_events_topic_arn" {}

--- a/infra/terraform/modules/data_access/lambda_users.tf
+++ b/infra/terraform/modules/data_access/lambda_users.tf
@@ -20,6 +20,7 @@ resource "aws_lambda_function" "create_user_role" {
         variables = {
             STAGE = "${var.env}",
             SAML_PROVIDER_ARN = "${var.saml_provider_arn}",
+            K8S_WORKER_ROLE_ARN = "${var.k8s_worker_role_arn}",
         }
     }
 }

--- a/infra/terraform/modules/data_access/users/tests/conftest.py
+++ b/infra/terraform/modules/data_access/users/tests/conftest.py
@@ -6,6 +6,7 @@ import pytest
 
 
 TEST_SAML_PROVIDER_ARN = "arn:aws:iam::123456789012:saml-provider/auth0"
+TEST_K8S_WORKER_ROLE_ARN = "arn:aws:iam::123456789012:role/nodes.test.example.com"
 TEST_STAGE = "test"
 TEST_USERNAME = "alice"
 TEST_ROLE_NAME = "{}_{}".format(TEST_STAGE, TEST_USERNAME)
@@ -18,6 +19,7 @@ def given_the_env_is_set():
     with mock.patch.dict("os.environ", {
         "STAGE": TEST_STAGE,
         "SAML_PROVIDER_ARN": TEST_SAML_PROVIDER_ARN,
+        "K8S_WORKER_ROLE_ARN": TEST_K8S_WORKER_ROLE_ARN,
     }):
         yield
 
@@ -38,6 +40,20 @@ def trust_relationship():
                         "SAML:aud": "https://signin.aws.amazon.com/saml"
                     }
                 }
+            },
+            {
+                "Effect": "Allow",
+                "Principal": {
+                    "Service": "ec2.amazonaws.com"
+                },
+                "Action": "sts:AssumeRole"
+            },
+            {
+                "Effect": "Allow",
+                "Principal": {
+                    "AWS": TEST_K8S_WORKER_ROLE_ARN
+                },
+                "Action": "sts:AssumeRole"
             }
         ]
     }

--- a/infra/terraform/modules/data_access/users/users.py
+++ b/infra/terraform/modules/data_access/users/users.py
@@ -17,6 +17,9 @@ def create_user_role(event, context):
 
     event = {"username": "alice"}
     """
+
+    # See: `sts:AssumeRole` required by kube2iam
+    # https://github.com/jtblin/kube2iam#iam-roles
     trust_relationship = {
         "Version": "2012-10-17",
         "Statement": [
@@ -31,6 +34,20 @@ def create_user_role(event, context):
                         "SAML:aud": "https://signin.aws.amazon.com/saml"
                     }
                 }
+            },
+            {
+                "Effect": "Allow",
+                "Principal": {
+                    "Service": "ec2.amazonaws.com"
+                },
+                "Action": "sts:AssumeRole"
+            },
+            {
+                "Effect": "Allow",
+                "Principal": {
+                    "AWS": os.environ["K8S_WORKER_ROLE_ARN"]
+                },
+                "Action": "sts:AssumeRole"
             }
         ]
     }


### PR DESCRIPTION
Allow users' IAM roles to be assumed by EC2 instances
This is to allow [kube2iam](https://github.com/jtblin/kube2iam#iam-roles) to
attach these roles to the users' EC2 instances.


## Ticket

https://trello.com/c/v1RDtzeB/230-s-fix-dataaccess-iam-roles-trust-relationship