### PR TITLE
Remove path from IAM roles and policies

### DIFF
--- a/infra/terraform/modules/data_access/lambda_memberships.tf
+++ b/infra/terraform/modules/data_access/lambda_memberships.tf
@@ -45,7 +45,7 @@ resource "aws_iam_role_policy" "attach_bucket_policy" {
         "iam:AttachRolePolicy"
       ],
       "Resource": [
-        "arn:aws:iam::${var.account_id}:role/users/${var.env}_*"
+        "arn:aws:iam::${var.account_id}:role/${var.env}_user_*"
       ]
     },
     {
@@ -106,7 +106,7 @@ resource "aws_iam_role_policy" "detach_bucket_policies" {
         "iam:DetachRolePolicy"
       ],
       "Resource": [
-        "arn:aws:iam::${var.account_id}:role/users/${var.env}_*"
+        "arn:aws:iam::${var.account_id}:role/${var.env}_user_*"
       ]
     },
     {

--- a/infra/terraform/modules/data_access/lambda_teams.tf
+++ b/infra/terraform/modules/data_access/lambda_teams.tf
@@ -105,7 +105,7 @@ resource "aws_iam_role_policy" "create_team_bucket_policies" {
         "iam:CreatePolicy"
       ],
       "Resource": [
-        "arn:aws:iam::${var.account_id}:policy/teams/${var.env}-*"
+        "arn:aws:iam::${var.account_id}:policy/${var.env}-*"
       ]
     },
     {
@@ -166,7 +166,7 @@ resource "aws_iam_role_policy" "delete_team_bucket_policies" {
         "iam:DeletePolicy"
       ],
       "Resource": [
-        "arn:aws:iam::${var.account_id}:policy/teams/${var.env}-*"
+        "arn:aws:iam::${var.account_id}:policy/${var.env}-*"
       ]
     },
     {

--- a/infra/terraform/modules/data_access/lambda_users.tf
+++ b/infra/terraform/modules/data_access/lambda_users.tf
@@ -46,7 +46,7 @@ resource "aws_iam_role_policy" "create_user_role_policy" {
         "iam:CreateRole"
       ],
       "Resource": [
-        "arn:aws:iam::${var.account_id}:role/users/${var.env}_*"
+        "arn:aws:iam::${var.account_id}:role/${var.env}_user_*"
       ]
     },
     {
@@ -108,7 +108,7 @@ resource "aws_iam_role_policy" "delete_user_role_policy" {
         "iam:DetachRolePolicy"
       ],
       "Resource": [
-        "arn:aws:iam::${var.account_id}:role/users/${var.env}_*"
+        "arn:aws:iam::${var.account_id}:role/${var.env}_user_*"
       ]
     },
     {

--- a/infra/terraform/modules/data_access/memberships/memberships.py
+++ b/infra/terraform/modules/data_access/memberships/memberships.py
@@ -95,7 +95,7 @@ def validate_policy_type(policy_type):
 
 
 def role_name(username):
-    return "{env}_{username}".format(
+    return "{env}_user_{username}".format(
         env=os.environ["STAGE"],
         username=username.lower(),
     )
@@ -107,7 +107,7 @@ def policy_arn(team_slug, policy_type):
         policy_type=policy_type,
     )
 
-    return "{iam_arn_base}:policy/teams/{policy_name}".format(
+    return "{iam_arn_base}:policy/{policy_name}".format(
         iam_arn_base=os.environ["IAM_ARN_BASE"],
         policy_name=policy_name,
     )

--- a/infra/terraform/modules/data_access/memberships/tests/conftest.py
+++ b/infra/terraform/modules/data_access/memberships/tests/conftest.py
@@ -11,8 +11,8 @@ TEST_TEAM_SLUG = "Justice-League"
 TEST_USERNAME = "Alice"
 
 TEST_BUCKET_NAME = "{}-{}".format(TEST_STAGE, TEST_TEAM_SLUG.lower())
-TEST_ROLE_NAME = "{}_{}".format(TEST_STAGE, TEST_USERNAME.lower())
-TEST_POLICY_ARN_PREFIX = "{iam_arn_base}:policy/teams/{bucket_name}".format(
+TEST_ROLE_NAME = "{}_user_{}".format(TEST_STAGE, TEST_USERNAME.lower())
+TEST_POLICY_ARN_PREFIX = "{iam_arn_base}:policy/{bucket_name}".format(
     iam_arn_base=TEST_IAM_ARN_BASE,
     bucket_name=TEST_BUCKET_NAME,
 )

--- a/infra/terraform/modules/data_access/teams/teams.py
+++ b/infra/terraform/modules/data_access/teams/teams.py
@@ -67,7 +67,6 @@ def create_policy(readwrite, bucket_name):
     client = boto3.client("iam")
     client.create_policy(
         PolicyName=policy_name,
-        Path="/teams/",
         PolicyDocument=json.dumps(get_policy_document(bucket_name, readwrite)),
     )
 
@@ -150,7 +149,7 @@ def delete_policy(name):
 
     LOG.debug("Deleting '{}' policy".format(name))
 
-    policy_arn = "{iam_arn_base}:policy/teams/{policy_name}".format(
+    policy_arn = "{iam_arn_base}:policy/{policy_name}".format(
         iam_arn_base=os.environ["IAM_ARN_BASE"],
         policy_name=name,
     )

--- a/infra/terraform/modules/data_access/teams/tests/conftest.py
+++ b/infra/terraform/modules/data_access/teams/tests/conftest.py
@@ -15,9 +15,9 @@ TEST_BUCKET_ARN = "arn:aws:s3:::{}".format(TEST_BUCKET_NAME)
 TEST_ROLE_NAME = "test-role"
 TEST_GROUP_NAME = "test-group"
 TEST_USER_NAME = "test-user"
-TEST_READONLY_POLICY_ARN = "{}:policy/teams/{}-readonly".format(
+TEST_READONLY_POLICY_ARN = "{}:policy/{}-readonly".format(
     TEST_IAM_ARN_BASE, TEST_BUCKET_NAME)
-TEST_READWRITE_POLICY_ARN = "{}:policy/teams/{}-readwrite".format(
+TEST_READWRITE_POLICY_ARN = "{}:policy/{}-readwrite".format(
     TEST_IAM_ARN_BASE, TEST_BUCKET_NAME)
 TEST_READONLY_POLICY_DOCUMENT = {
     "Version": "2012-10-17",

--- a/infra/terraform/modules/data_access/teams/tests/test_create_team_bucket_policies.py
+++ b/infra/terraform/modules/data_access/teams/tests/test_create_team_bucket_policies.py
@@ -23,12 +23,10 @@ def test_when_the_team_is_created_the_bucket_policies_are_created(iam_client_moc
     calls = [
         call(
             PolicyName="{}-readonly".format(TEST_BUCKET_NAME),
-            Path="/teams/",
             PolicyDocument=json.dumps(TEST_READONLY_POLICY_DOCUMENT),
         ),
         call(
             PolicyName="{}-readwrite".format(TEST_BUCKET_NAME),
-            Path="/teams/",
             PolicyDocument=json.dumps(TEST_READWRITE_POLICY_DOCUMENT),
         )
     ]

--- a/infra/terraform/modules/data_access/users/tests/conftest.py
+++ b/infra/terraform/modules/data_access/users/tests/conftest.py
@@ -9,7 +9,7 @@ TEST_SAML_PROVIDER_ARN = "arn:aws:iam::123456789012:saml-provider/auth0"
 TEST_K8S_WORKER_ROLE_ARN = "arn:aws:iam::123456789012:role/nodes.test.example.com"
 TEST_STAGE = "test"
 TEST_USERNAME = "Alice"
-TEST_ROLE_NAME = "{}_{}".format(TEST_STAGE, TEST_USERNAME.lower())
+TEST_ROLE_NAME = "{}_user_{}".format(TEST_STAGE, TEST_USERNAME.lower())
 
 TEST_ROLE_POLICY_ARN = "test_policy_arn"
 

--- a/infra/terraform/modules/data_access/users/tests/test_create_user_role.py
+++ b/infra/terraform/modules/data_access/users/tests/test_create_user_role.py
@@ -17,6 +17,5 @@ def test_create_user_role_success(iam_client_mock, trust_relationship):
     # Test role is created
     iam_client_mock.create_role.assert_called_with(
         RoleName=TEST_ROLE_NAME,
-        Path="/users/",
         AssumeRolePolicyDocument=json.dumps(trust_relationship),
     )

--- a/infra/terraform/modules/data_access/users/users.py
+++ b/infra/terraform/modules/data_access/users/users.py
@@ -55,7 +55,6 @@ def create_user_role(event, context):
     client = boto3.client("iam")
     client.create_role(
         RoleName=role_name(event["username"]),
-        Path="/users/",
         AssumeRolePolicyDocument=json.dumps(trust_relationship),
     )
 
@@ -86,7 +85,7 @@ def detach_role_policies(role_name):
 
 
 def role_name(username):
-    return "{env}_{username}".format(
+    return "{env}_user_{username}".format(
         env=os.environ["STAGE"],
         username=username.lower(),
     )


### PR DESCRIPTION
### Why

They don't add much value at the moment and the R library we currently use
(Cloudyr) is ignoring them causing problems.


### IAM changes

The IAM role names will now be in the format `$ENV_user_$USERNAME`.
The IAM policies will also lose the path but their name doesn't change.


### Ticket

https://trello.com/c/8hp1cSPd/229-s-get-right-of-users-path-in-dataaccess-iam-roles