### PR TITLE
Add S3 logging setup to team bucket creation lambda function

### DIFF
--- a/infra/terraform/environments/alpha/main.tf
+++ b/infra/terraform/environments/alpha/main.tf
@@ -122,6 +122,7 @@ module "data_access" {
     membership_events_topic_arn = "${module.notifications.membership_events_topic_arn}"
     organization_events_topic_arn = "${module.notifications.organization_events_topic_arn}"
     team_events_topic_arn = "${module.notifications.team_events_topic_arn}"
+    logs_bucket_name = "${module.data_buckets.logs_bucket_name}"
 }
 
 module "federated_identity" {

--- a/infra/terraform/environments/dev/main.tf
+++ b/infra/terraform/environments/dev/main.tf
@@ -122,6 +122,7 @@ module "data_access" {
     membership_events_topic_arn = "${module.notifications.membership_events_topic_arn}"
     organization_events_topic_arn = "${module.notifications.organization_events_topic_arn}"
     team_events_topic_arn = "${module.notifications.team_events_topic_arn}"
+    logs_bucket_name = "${module.data_buckets.logs_bucket_name}"
 }
 
 module "federated_identity" {

--- a/infra/terraform/modules/data_access/inputs.tf
+++ b/infra/terraform/modules/data_access/inputs.tf
@@ -10,3 +10,4 @@ variable "k8s_worker_role_arn" {}
 variable "membership_events_topic_arn" {}
 variable "organization_events_topic_arn" {}
 variable "team_events_topic_arn" {}
+variable "logs_bucket_name" {}

--- a/infra/terraform/modules/data_access/lambda_teams.tf
+++ b/infra/terraform/modules/data_access/lambda_teams.tf
@@ -56,7 +56,8 @@ resource "aws_iam_role_policy" "create_team_bucket" {
       "Sid": "CanCreateBuckets",
       "Effect": "Allow",
       "Action": [
-        "s3:CreateBucket"
+        "s3:CreateBucket",
+        "s3:PutBucketLogging"
       ],
       "Resource": [
         "arn:aws:s3:::${var.env}-*"

--- a/infra/terraform/modules/data_access/lambda_teams.tf
+++ b/infra/terraform/modules/data_access/lambda_teams.tf
@@ -34,6 +34,7 @@ resource "aws_lambda_function" "create_team_bucket" {
             BUCKET_REGION = "${var.region}",
             STAGE = "${var.env}",
             SENTRY_DSN = "${var.sentry_dsn}",
+            LOGS_BUCKET_NAME = "${var.logs_bucket_name}",
         }
     }
 }

--- a/infra/terraform/modules/data_access/teams/teams.py
+++ b/infra/terraform/modules/data_access/teams/teams.py
@@ -43,7 +43,7 @@ def send_exceptions_to_sentry(fn):
 @send_exceptions_to_sentry
 def create_team_bucket(event, context):
     """
-    Creates the team's S3 bucket
+    Creates the team's S3 bucket, with logging enabled
 
     event = {"team": {"slug": "justice-league"}}
     """
@@ -61,6 +61,15 @@ def create_team_bucket(event, context):
         Bucket=name,
         ACL="private",
         CreateBucketConfiguration={"LocationConstraint": region},
+    )
+    client.put_bucket_logging(
+        Bucket=name,
+        BucketLoggingStatus={
+            'LoggingEnabled': {
+                'TargetBucket': os.environ.get('LOGS_BUCKET_NAME'),
+                'TargetPrefix': "s3/{}/".format(name)
+            }
+        },
     )
 
 
@@ -256,3 +265,8 @@ def bucket_name(slug):
     name = name.strip("-")
 
     return "{}-{}".format(os.environ["STAGE"], name)
+
+
+# def logs_bucket_name():
+#     return "{}-{}".format(os.environ['STAGE'],
+#                           os.environ['LOGS_BUCKET_NAME_SUFFIX'])

--- a/infra/terraform/modules/data_access/teams/teams.py
+++ b/infra/terraform/modules/data_access/teams/teams.py
@@ -265,8 +265,3 @@ def bucket_name(slug):
     name = name.strip("-")
 
     return "{}-{}".format(os.environ["STAGE"], name)
-
-
-# def logs_bucket_name():
-#     return "{}-{}".format(os.environ['STAGE'],
-#                           os.environ['LOGS_BUCKET_NAME_SUFFIX'])

--- a/infra/terraform/modules/data_access/teams/teams.py
+++ b/infra/terraform/modules/data_access/teams/teams.py
@@ -66,7 +66,7 @@ def create_team_bucket(event, context):
         Bucket=name,
         BucketLoggingStatus={
             'LoggingEnabled': {
-                'TargetBucket': os.environ.get('LOGS_BUCKET_NAME'),
+                'TargetBucket': os.environ['LOGS_BUCKET_NAME'],
                 'TargetPrefix': "s3/{}/".format(name)
             }
         },

--- a/infra/terraform/modules/data_access/teams/tests/conftest.py
+++ b/infra/terraform/modules/data_access/teams/tests/conftest.py
@@ -66,6 +66,8 @@ TEST_READWRITE_POLICY_DOCUMENT["Statement"].append(
         "Resource": "{}/*".format(TEST_BUCKET_ARN)
     }
 )
+TEST_LOGS_PREFIX = "s3/{}/".format(TEST_BUCKET_NAME)
+TEST_LOGS_BUCKET_NAME = "test-logs"
 
 
 @pytest.yield_fixture
@@ -74,6 +76,7 @@ def given_the_env_is_set():
         "BUCKET_REGION": TEST_BUCKET_REGION,
         "IAM_ARN_BASE": TEST_IAM_ARN_BASE,
         "STAGE": TEST_STAGE,
+        "LOGS_BUCKET_NAME": TEST_LOGS_BUCKET_NAME,
     }):
         yield
 

--- a/infra/terraform/modules/data_access/teams/tests/test_create_team_bucket.py
+++ b/infra/terraform/modules/data_access/teams/tests/test_create_team_bucket.py
@@ -2,9 +2,12 @@ import pytest
 
 import teams
 
-from tests.conftest import (TEST_TEAM_SLUG, TEST_BUCKET_NAME,
-                            TEST_BUCKET_REGION, TEST_LOGS_BUCKET_NAME,
-                            TEST_LOGS_PREFIX)
+from tests.conftest import (
+    TEST_TEAM_SLUG,
+    TEST_BUCKET_NAME,
+    TEST_BUCKET_REGION,
+    TEST_LOGS_BUCKET_NAME,
+    TEST_LOGS_PREFIX)
 
 
 @pytest.mark.usefixtures(

--- a/infra/terraform/modules/data_access/teams/tests/test_create_team_bucket.py
+++ b/infra/terraform/modules/data_access/teams/tests/test_create_team_bucket.py
@@ -1,10 +1,10 @@
-import json
-
 import pytest
 
 import teams
 
-from tests.conftest import TEST_TEAM_SLUG, TEST_BUCKET_NAME, TEST_BUCKET_REGION
+from tests.conftest import (TEST_TEAM_SLUG, TEST_BUCKET_NAME,
+                            TEST_BUCKET_REGION, TEST_LOGS_BUCKET_NAME,
+                            TEST_LOGS_PREFIX)
 
 
 @pytest.mark.usefixtures(
@@ -19,5 +19,23 @@ def test_when_the_team_is_created_the_bucket_is_created(s3_client_mock):
         ACL="private",
         CreateBucketConfiguration={
             "LocationConstraint": TEST_BUCKET_REGION,
+        },
+    )
+
+
+@pytest.mark.usefixtures(
+    "given_the_env_is_set",
+    "given_s3_is_available",
+)
+def test_when_team_bucket_is_created_logging_is_enabled(s3_client_mock):
+    teams.create_team_bucket({"team": {"slug": TEST_TEAM_SLUG}}, None)
+
+    s3_client_mock.put_bucket_logging.assert_called_with(
+        Bucket=TEST_BUCKET_NAME,
+        BucketLoggingStatus={
+            'LoggingEnabled': {
+                'TargetBucket': TEST_LOGS_BUCKET_NAME,
+                'TargetPrefix': TEST_LOGS_PREFIX
+            }
         },
     )

--- a/infra/terraform/modules/data_buckets/main.tf
+++ b/infra/terraform/modules/data_buckets/main.tf
@@ -13,6 +13,10 @@ output "logs_bucket_arn" {
     value = "${aws_s3_bucket.logs.arn}"
 }
 
+output "logs_bucket_name" {
+    value = "${aws_s3_bucket.logs.id}"
+}
+
 output "iam_managers_arn" {
     value = "${aws_iam_group.managers.arn}"
 }

--- a/infra/terraform/modules/data_buckets/s3.tf
+++ b/infra/terraform/modules/data_buckets/s3.tf
@@ -18,7 +18,7 @@ resource "aws_s3_bucket" "scratch" {
 
 resource "aws_s3_bucket" "logs" {
     bucket = "${var.env}-moj-analytics-logs"
-    acl = "private"
+    acl = "log-delivery-write"
 
     tags {
         Name = "${var.env}-moj-analytics-logs"


### PR DESCRIPTION
## What

Each bucket created by the team bucket lambda function requires access logs to be enabled. These changes ensure that all buckets created from github events have logging configured to send logs to a per-environment bucket, with an `s3/team-bucket-name/` prefix, to keep S3 logs separate from future CloudTrail logs, and to keep bucket logs separate from each other.

## How to review

1. Terraform apply
2. Create a team bucket via github or the Lambda console
3. Check that logging is enabled via the S3 console, or:
4. Upload a file to the team bucket and verify that logs are created (may take up to 1 hour)