### PR TITLE
Shiny helm chart: Fix for "upgrade failed expected string got bool"

### DIFF
--- a/charts/shiny-app/templates/deployment.yaml
+++ b/charts/shiny-app/templates/deployment.yaml
@@ -53,9 +53,9 @@ spec:
             - name: TARGET_URL
               value: "http://localhost:{{ .Values.shinyApp.port }}/"
             - name: AUTHENTICATION_REQUIRED
-              value: {{ .Values.AuthProxy.AuthenticationRequired }}
+              value: "{{ .Values.AuthProxy.AuthenticationRequired }}"
             - name: IP_RANGES
-              value: {{ .Values.AuthProxy.IPRanges }}
+              value: "{{ .Values.AuthProxy.IPRanges }}"
             - name: AUTH0_PASSWORDLESS
               value: "true"
             - name: PORT

--- a/charts/shiny-app/values.yaml
+++ b/charts/shiny-app/values.yaml
@@ -8,7 +8,7 @@ app:
   port: 80
   repo: ""
 AuthProxy:
-  AuthenticationRequired: true
+  AuthenticationRequired: "true"
   IPRanges: ""
   Image:
     Repository: quay.io/mojanalytics/auth-proxy


### PR DESCRIPTION
I'm see this error in Jenkins and it's likely caused by the fact that
the `AuthProxy.AuthenticationRequired` value is `true` (boolean) instead of
`"true"` (string)

Error:

    Error: UPGRADE FAILED: error validating "": error validating data: expected type string, for field spec.template.spec.containers[0].env[7].value, got bool

## Ticket

Part of https://trello.com/c/UVgHMv1C/223-l-allow-ip-based-access-control-to-shiny-apps-for-dom1-quantum-etc-instead-of-or-as-well-as-user-based-access-controls