### PR TITLE
Grant Access jenkins job: Improved wording to avoid confusion

### DIFF
--- a/jenkinsfiles/grant_access_to_app.groovy
+++ b/jenkinsfiles/grant_access_to_app.groovy
@@ -3,7 +3,7 @@ pipeline {
     agent any
 
     parameters{
-        string(name: 'APP_NAME', description: 'Shiny App name')
+        string(name: 'APP_NAME', description: 'Shiny App name: e.g. rshiny-test')
         string(name: 'EMAILS', description: 'List of email addresses')
     }
 


### PR DESCRIPTION
The `APP_NAME` parameter is just the app name, not the whole URL. Changing
the wording to add an example and avoid confusion as suggested by Robin.