### PR TITLE
attach_bucket_policy lambda function retries twice before notifying Sentry

### DIFF
--- a/infra/terraform/modules/data_access/lambda_memberships.tf
+++ b/infra/terraform/modules/data_access/lambda_memberships.tf
@@ -5,8 +5,7 @@ resource "null_resource" "memberships_install_deps" {
     }
 
     triggers {
-        build_sh_sha = "${sha256(file("${path.module}/memberships/build.sh"))}"
-        requirements_sha = "${sha256(file("${path.module}/memberships/requirements.txt"))}"
+        force_rebuild = "${timestamp()}"
     }
 }
 

--- a/infra/terraform/modules/data_access/lambda_teams.tf
+++ b/infra/terraform/modules/data_access/lambda_teams.tf
@@ -5,8 +5,7 @@ resource "null_resource" "teams_install_deps" {
     }
 
     triggers {
-        build_sh_sha = "${sha256(file("${path.module}/teams/build.sh"))}"
-        requirements_sha = "${sha256(file("${path.module}/teams/requirements.txt"))}"
+        force_rebuild = "${timestamp()}"
     }
 }
 

--- a/infra/terraform/modules/data_access/lambda_users.tf
+++ b/infra/terraform/modules/data_access/lambda_users.tf
@@ -5,8 +5,7 @@ resource "null_resource" "users_install_deps" {
     }
 
     triggers {
-        build_sh_sha = "${sha256(file("${path.module}/users/build.sh"))}"
-        requirements_sha = "${sha256(file("${path.module}/users/requirements.txt"))}"
+        force_rebuild = "${timestamp()}"
     }
 }
 

--- a/infra/terraform/modules/data_access/memberships/.gitignore
+++ b/infra/terraform/modules/data_access/memberships/.gitignore
@@ -1,0 +1,4 @@
+contextlib2*
+naming*
+raven*
+sentry*

--- a/infra/terraform/modules/data_access/memberships/memberships.py
+++ b/infra/terraform/modules/data_access/memberships/memberships.py
@@ -63,7 +63,7 @@ def attach_bucket_policy(event, context):
     retry(fn)
 
 
-def retry(fn, max_attempts=5, delay=0.150):
+def retry(fn, max_attempts=10, delay=0.200):
     attempts = 0
     while True:
         try:

--- a/infra/terraform/modules/data_access/users/.gitignore
+++ b/infra/terraform/modules/data_access/users/.gitignore
@@ -1,0 +1,4 @@
+contextlib2*
+naming*
+raven*
+sentry*


### PR DESCRIPTION
## What (NOW)

We now catch this specific exception and retry twice after a brief amount of
time (200ms, tested). This prevent the lambda failing and the error to get
to us unless can't be handled this way.

## Why (BEFORE)

Because of the asyncronous nature of these lambda functions, when creating
a new team or the user is new to the organisation:
1) The team bucket's IAM policy may not be created yet
2) The user's IAM role may not be created yet

In these two cases the `attach_bucket_policy` lambda function would raise
an [`NoSuchEntity` exception](https://sentry.service.dsd.io/mojds/data-access-lambda/issues/5251/events/146927/).
AWS will automatically retry and succeed but we'll be notified about this
error via Sentry.

## Benefits

Add a retry/sleep is not the pretties thing but:
1) From my manual experiments I've noticed that sleeping and retrying actually
   improve the overall execution time. This is because not retrying will
   cause a HTTP request to Sentry which increases the total execution time
   (sometimes ~1000-1100ms), plus the execution time on the AWS retry (~700ms).
   Conversely, sleep 200ms would cause the lambda function to succeed and
   avoid the HTTP call to Sentry and the AWS retry bringing the total execution
   time when this exception happen to ~1300ms (from 1700ms = 1000ms + 700ms)
2) We have a very low number of invocation and we don't exceed the free tier
3) Have false positive sentry errors lead to ignore the actual errors

## Ticket

https://trello.com/c/3VbPHbM9/273-retry-mechanism-for-dataaccess-lambdas