### PR TITLE
Terraform: Fixed S3 logs bucket references (in alpha env)

### DIFF
--- a/infra/terraform/environments/alpha/main.tf
+++ b/infra/terraform/environments/alpha/main.tf
@@ -124,7 +124,7 @@ module "data_access" {
     membership_events_topic_arn = "${module.notifications.membership_events_topic_arn}"
     organization_events_topic_arn = "${module.notifications.organization_events_topic_arn}"
     team_events_topic_arn = "${module.notifications.team_events_topic_arn}"
-    logs_bucket_name = "${module.data_buckets.logs_bucket_name}"
+    logs_bucket_name = "${data.terraform_remote_state.base.s3_logs_bucket_name}"
 }
 
 module "federated_identity" {


### PR DESCRIPTION
Same as 9808ea95871b407d2bb65fa2c4099881ef5585f2 but in `alpha` environment

Without this `terraform plan` in `alpha` will fail.