### PR TITLE
Fix cloudtrail logs geoip pipeline and errors with digest files

### DIFF
--- a/infra/terraform/global/main.tf
+++ b/infra/terraform/global/main.tf
@@ -23,6 +23,8 @@ module "aws_account_logging" {
 
     cloudtrail_s3_bucket_arn = "${aws_s3_bucket.global_cloudtrail.arn}"
     cloudtrail_s3_bucket_id = "${aws_s3_bucket.global_cloudtrail.id}"
+
+    account_id = "${data.aws_caller_identity.current.account_id}"
 }
 
 module "log_pruning" {

--- a/infra/terraform/modules/aws_account_logging/cloudtrail-lambda.tf
+++ b/infra/terraform/modules/aws_account_logging/cloudtrail-lambda.tf
@@ -56,6 +56,7 @@ resource "aws_s3_bucket_notification" "cloudtrail_object_created" {
   lambda_function {
     lambda_function_arn = "${aws_lambda_function.cloudtrail_to_elasticsearch.arn}"
     events              = ["s3:ObjectCreated:*"]
+    filter_prefix       = "AWSLogs/${var.account_id}/CloudTrail/"
   }
 
 }

--- a/infra/terraform/modules/aws_account_logging/cloudtrail/.gitignore
+++ b/infra/terraform/modules/aws_account_logging/cloudtrail/.gitignore
@@ -1,4 +1,9 @@
-requests*
-s3_log_parser*
-ua_parser*
-user_agents*
+*.dist-info
+*.egg-info
+certifi
+elasticsearch
+requests
+s3_log_parser
+ua_parser
+urllib3
+user_agents

--- a/infra/terraform/modules/aws_account_logging/cloudtrail/cloudtrail_to_es.py
+++ b/infra/terraform/modules/aws_account_logging/cloudtrail/cloudtrail_to_es.py
@@ -8,8 +8,8 @@ import ipaddress
 import boto3
 from botocore.client import Config
 import certifi
-import elasticsearch
 from elasticsearch import Elasticsearch
+import elasticsearch.helpers
 
 
 LOG = logging.getLogger(__name__)

--- a/infra/terraform/modules/aws_account_logging/cloudtrail/cloudtrail_to_es.py
+++ b/infra/terraform/modules/aws_account_logging/cloudtrail/cloudtrail_to_es.py
@@ -7,76 +7,30 @@ import ipaddress
 
 import boto3
 from botocore.client import Config
-import requests
-from requests.auth import HTTPBasicAuth
+import certifi
+import elasticsearch
+from elasticsearch import Elasticsearch
 
 
 LOG = logging.getLogger(__name__)
 LOG.setLevel(os.environ.get('LOG_LEVEL', 'DEBUG'))
 
+ca_certs = certifi.where()
 s3 = boto3.client('s3', config=Config(signature_version='s3v4'))
 
 
 def lambda_handler(event, context):
     LOG.debug('Received S3 event: {}'.format(event))
 
+    config = elasticsearch_config(os.environ)
+
     for record in event['Records']:
         log_file = log_file_s3_object(record)
-        add_elasticsearch_index(log_file)
+        add_elasticsearch_index(log_file, config)
 
 
-def log_file_s3_object(record):
-    return gzip.decompress(s3.get_object(
-        Bucket=record['s3']['bucket']['name'],
-        Key=record['s3']['object']['key'])['Body'].read())
-
-
-def add_elasticsearch_index(log_file):
-    for entry in log_entries(log_file):
-        post_to_elasticsearch(parse_log_entry(entry))
-
-
-def log_entries(log_file):
-
-    log_data = json.loads(log_file)
-
-    for record in log_data['Records']:
-        yield record
-
-
-def post_to_elasticsearch(doc):
-    LOG.debug('Posting to elasticsearch: {}'.format(doc))
-
-    params = {}
-
-    if is_ipaddress(doc.get('sourceIPAddress')):
-        params['pipeline'] = 'cloudtrail-geoip'
-
-    # TODO handle errors
-    response = requests.post(
-        elasticsearch_url(os.environ),
-        params=params,
-        auth=elasticsearch_auth_header(os.environ),
-        json=doc)
-
-    LOG.debug('Elasticsearch response: {status} - {text}'.format(
-        status=response.status_code,
-        text=response.text))
-
-
-def is_ipaddress(value):
-    try:
-        ipaddress.ip_address(value)
-
-    except ValueError:
-        return False
-
-    return True
-
-
-def elasticsearch_url(env):
-
-    values = {
+def elasticsearch_config(env):
+    defaults = {
         'scheme': 'http',
         'domain': 'localhost',
         'port': '9200',
@@ -84,11 +38,7 @@ def elasticsearch_url(env):
         'doctype': 'cloudtrail-log'
     }
 
-    values.update(elasticsearch_env_vars(env))
-
-    return '{scheme}://{domain}:{port}/{index}/{doctype}'.format(
-        index=elasticsearch_url_index(values['index_prefix']),
-        **values)
+    return dict(defaults, **elasticsearch_env_vars(env))
 
 
 def elasticsearch_env_vars(env):
@@ -103,7 +53,36 @@ def elasticsearch_env_vars(env):
     return values
 
 
-def elasticsearch_url_index(prefix, today=None):
+def log_file_s3_object(record):
+    return gzip.decompress(s3.get_object(
+        Bucket=record['s3']['bucket']['name'],
+        Key=record['s3']['object']['key'])['Body'].read())
+
+
+def add_elasticsearch_index(log_file, config):
+    es = elasticsearch_connection(config)
+    index = elasticsearch_index(config['index_prefix'])
+
+    successful, errors = elasticsearch.helpers.bulk(
+        es, add_to_index(log_entries(log_file), index))
+
+    LOG.debug((
+        'Elasticsearch response: {successful} succeeded. '
+        'Errors: {errors}').format(successful=successful, errors=errors))
+
+
+def elasticsearch_connection(config):
+
+    return Elasticsearch(
+        '{scheme}://{domain}:{port}'.format(**config),
+        http_auth=(config['username'], config['password']),
+        timeout=300,
+        use_ssl=True,
+        verify_certs=True,
+        ca_certs=ca_certs)
+
+
+def elasticsearch_index(prefix, today=None):
 
     if today is None:
         today = datetime.datetime.utcnow()
@@ -113,14 +92,44 @@ def elasticsearch_url_index(prefix, today=None):
         date=today)
 
 
-def elasticsearch_auth_header(env):
-    return HTTPBasicAuth(
-        env.get('ES_USERNAME'),
-        env.get('ES_PASSWORD'))
+def add_to_index(docs, index):
+    for doc in docs:
+        LOG.debug('Posting to elasticsearch: {}'.format(doc))
+
+        yield {
+            '_op_type': 'index',
+            '_index': index,
+            '_type': 'cloudtrail-log',
+            'pipeline': pipeline(doc),
+            '_source': doc
+        }
+
+
+def pipeline(doc):
+    if is_ipaddress(doc.get('sourceIPAddress')):
+        return 'cloudtrail-geoip'
+
+    return None
+
+
+def is_ipaddress(value):
+    try:
+        ipaddress.ip_address(value)
+
+    except ValueError:
+        return False
+
+    return True
+
+
+def log_entries(log_file):
+    log_data = json.loads(log_file)
+
+    for record in log_data['Records']:
+        yield parse_log_entry(record)
 
 
 def parse_log_entry(entry):
-
     LOG.debug('Parsing log entry: {}'.format(entry))
 
     return entry

--- a/infra/terraform/modules/aws_account_logging/cloudtrail/requirements.txt
+++ b/infra/terraform/modules/aws_account_logging/cloudtrail/requirements.txt
@@ -1,1 +1,2 @@
-requests==2.13.0
+certifi==2016.8.8
+elasticsearch>=5.0.0,<6.0.0

--- a/infra/terraform/modules/aws_account_logging/main.tf
+++ b/infra/terraform/modules/aws_account_logging/main.tf
@@ -7,3 +7,4 @@ variable "es_scheme" {
 }
 variable "cloudtrail_s3_bucket_id" {}
 variable "cloudtrail_s3_bucket_arn" {}
+variable "account_id" {}


### PR DESCRIPTION
  - Cloudtrail logs `sourceIPAddress` sometimes contains a hostname rather than an IP address, which causes errors with Elasticsearch, so don't use the pipeline in those cases
  - Exclude Cloudtrail digest files from lambda function trigger