### PR TITLE
Add IAM role for Control Panel API

### DIFF
--- a/infra/terraform/environments/alpha/main.tf
+++ b/infra/terraform/environments/alpha/main.tf
@@ -131,3 +131,10 @@ module "federated_identity" {
     source ="../../modules/federated_identity"
     env = "${var.env}"
 }
+
+module "control_panel_role" {
+    source = "../../modules/control_panel_role"
+
+    env = "${var.env}"
+    account_id = "${data.aws_caller_identity.current.account_id}"
+}

--- a/infra/terraform/environments/dev/main.tf
+++ b/infra/terraform/environments/dev/main.tf
@@ -137,3 +137,10 @@ module "control_panel_db" {
     db_subnet_ids = ["${module.aws_vpc.storage_subnet_ids}"]
     ingress_security_group_ids = ["${module.aws_vpc.extra_node_sg_id}"]
 }
+
+module "control_panel_role" {
+    source = "../../modules/control_panel_role"
+
+    env = "${var.env}"
+    account_id = "${data.aws_caller_identity.current.account_id}"
+}

--- a/infra/terraform/modules/control_panel_role/inputs.tf
+++ b/infra/terraform/modules/control_panel_role/inputs.tf
@@ -1,0 +1,2 @@
+variable "env" {}
+variable "account_id" {}

--- a/infra/terraform/modules/control_panel_role/outputs.tf
+++ b/infra/terraform/modules/control_panel_role/outputs.tf
@@ -1,0 +1,3 @@
+output "control_panel_api_role_name" {
+    value = "${aws_iam_role.control_panel_api.name}"
+}

--- a/infra/terraform/modules/control_panel_role/role.tf
+++ b/infra/terraform/modules/control_panel_role/role.tf
@@ -1,0 +1,114 @@
+resource "aws_iam_role" "control_panel_api" {
+    name = "${var.env}_control_panel_api"
+    description = "IAM role assumed by the Control Panel API"
+    assume_role_policy = <<EOF
+    {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Action": "sts:AssumeRole",
+          "Principal": {
+            "Service": "ec2.amazonaws.com"
+          },
+          "Effect": "Allow",
+          "Sid": ""
+        }
+      ]
+    }
+EOF
+}
+
+resource "aws_iam_policy" "control_panel_api" {
+    name = "${var.env}_control_panel_api"
+    policy = <<EOF
+    {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Sid": "CanCreateBuckets",
+          "Effect": "Allow",
+          "Action": [
+            "s3:CreateBucket",
+            "s3:PutBucketLogging"
+          ],
+          "Resource": [
+            "arn:aws:s3:::${var.env}-*"
+          ]
+        },
+        {
+          "Sid": "CanCreateIAMPolicies",
+          "Effect": "Allow",
+          "Action": [
+            "iam:CreatePolicy"
+          ],
+          "Resource": [
+            "arn:aws:iam::${var.account_id}:policy/${var.env}-*"
+          ]
+        },
+        {
+          "Sid": "CanDeleteIAMPolicies",
+          "Effect": "Allow",
+          "Action": [
+            "iam:DeletePolicy"
+          ],
+          "Resource": [
+            "arn:aws:iam::${var.account_id}:policy/${var.env}-*"
+          ]
+        },
+        {
+          "Sid": "CanDetachPolicies",
+          "Effect": "Allow",
+          "Action": [
+            "iam:ListEntitiesForPolicy",
+            "iam:DetachGroupPolicy",
+            "iam:DetachRolePolicy",
+            "iam:DetachUserPolicy"
+          ],
+          "Resource": [
+            "arn:aws:iam::${var.account_id}:*"
+          ]
+        },
+        {
+          "Sid": "CanAttachPolicy",
+          "Effect": "Allow",
+          "Action": [
+            "iam:AttachRolePolicy"
+          ],
+          "Resource": [
+            "arn:aws:iam::${var.account_id}:role/${var.env}_user_*",
+            "arn:aws:iam::${var.account_id}:role/${var.env}_app_*"
+          ]
+        },
+        {
+          "Sid": "CanCreateRoles",
+          "Effect": "Allow",
+          "Action": [
+            "iam:CreateRole"
+          ],
+          "Resource": [
+            "arn:aws:iam::${var.account_id}:role/${var.env}_user_*",
+            "arn:aws:iam::${var.account_id}:role/${var.env}_app_*"
+          ]
+        },
+        {
+          "Sid": "CanDeleteRoles",
+          "Effect": "Allow",
+          "Action": [
+            "iam:DeleteRole",
+            "iam:ListAttachedRolePolicies",
+            "iam:DetachRolePolicy"
+          ],
+          "Resource": [
+            "arn:aws:iam::${var.account_id}:role/${var.env}_user_*",
+            "arn:aws:iam::${var.account_id}:role/${var.env}_app_*"
+          ]
+        }
+      ]
+    }
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "control_panel_api" {
+    role       = "${aws_iam_role.control_panel_api.name}"
+    policy_arn = "${aws_iam_policy.control_panel_api.arn}"
+}


### PR DESCRIPTION
## What

IAM role assumed by the Control Panel API instances and grant them permissions to perform all the required operations:

 - create S3 buckets
 - create IAM policies to access them
 - delete IAM policies
 - attach IAM policies to user/app roles (to grant them access to an S3
   bucket)
 - detach IAM policies (to revoke user/app access to an S3 bucket)
 - can create users/apps IAM roles
 - can delete users/apps IAM roles


## Related PRs
- Used by helm chart: https://github.com/ministryofjustice/analytics-platform-helm-charts/pull/16
- cpanel helm chart config: https://github.com/ministryofjustice/analytics-platform-config/pull/8
## Ticket
https://trello.com/c/AULNJYns/359-add-iam-role-for-control-panel-api-app-to-terraform