### PR TITLE
Fix control_panel_api IAM role

### DIFF
--- a/infra/terraform/environments/alpha/main.tf
+++ b/infra/terraform/environments/alpha/main.tf
@@ -137,6 +137,7 @@ module "federated_identity" {
 #     env = "${var.env}"
 #     db_username = "${var.control_panel_api_db_username}"
 #     db_password = "${var.control_panel_api_db_password}"
+#     k8s_worker_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/nodes.${var.env}.${data.terraform_remote_state.base.xyz_root_domain}"
 #     account_id = "${data.aws_caller_identity.current.account_id}"
 #     vpc_id = "${module.aws_vpc.vpc_id}"
 #     db_subnet_ids = ["${module.aws_vpc.storage_subnet_ids}"]

--- a/infra/terraform/environments/dev/main.tf
+++ b/infra/terraform/environments/dev/main.tf
@@ -135,6 +135,7 @@ module "control_panel_api" {
     env = "${var.env}"
     db_username = "${var.control_panel_api_db_username}"
     db_password = "${var.control_panel_api_db_password}"
+    k8s_worker_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/nodes.${var.env}.${data.terraform_remote_state.base.xyz_root_domain}"
     account_id = "${data.aws_caller_identity.current.account_id}"
     vpc_id = "${module.aws_vpc.vpc_id}"
     db_subnet_ids = ["${module.aws_vpc.storage_subnet_ids}"]

--- a/infra/terraform/modules/control_panel_api/inputs.tf
+++ b/infra/terraform/modules/control_panel_api/inputs.tf
@@ -2,6 +2,8 @@ variable "env" {}
 variable "vpc_id" {}
 variable "account_id" {}
 
+variable "k8s_worker_role_arn" {}
+
 variable "db_username" {}
 variable "db_password" {}
 

--- a/infra/terraform/modules/control_panel_api/role.tf
+++ b/infra/terraform/modules/control_panel_api/role.tf
@@ -12,6 +12,13 @@ resource "aws_iam_role" "control_panel_api" {
       },
       "Effect": "Allow",
       "Sid": ""
+    },
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "${var.k8s_worker_role_arn}"
+      },
+      "Action": "sts:AssumeRole"
     }
   ]
 }


### PR DESCRIPTION
### What
The `control_panel_api` IAM role wasn't assumed by the control panel API
instances. The problem was a missing statement with the k8s workers role
ARN as principal.

This is necessary in order for kube2iam to work as expected (see below)

### `sts:AssumeRole` required by kube2iam

See kube2iam documentation on assume role/trust relationship the IAM role needs:
https://github.com/jtblin/kube2iam#iam-roles

### Ticket:

https://trello.com/c/hSOlOUmE/391-cp-api-bug-unable-to-locate-aws-credentials