### PR TITLE
Lambda functions zips depends on script which install dependences

### DIFF
--- a/infra/terraform/modules/data_access/lambda_memberships.tf
+++ b/infra/terraform/modules/data_access/lambda_memberships.tf
@@ -14,6 +14,8 @@ data "archive_file" "memberships_zip" {
     type        = "zip"
     source_dir  = "${path.module}/memberships"
     output_path = "/tmp/memberships.zip"
+
+    depends_on = ["null_resource.memberships_install_deps"]
 }
 
 # Lambda function to attach bucket IAM policy to IAM role

--- a/infra/terraform/modules/data_access/lambda_users.tf
+++ b/infra/terraform/modules/data_access/lambda_users.tf
@@ -14,6 +14,8 @@ data "archive_file" "users_zip" {
     type        = "zip"
     source_dir  = "${path.module}/users"
     output_path = "/tmp/users.zip"
+
+    depends_on = ["null_resource.users_install_deps"]
 }
 
 # Lambda function adds an IAM role given its username


### PR DESCRIPTION
### What

Two of the lambda functions' zips which must include some dependences
were not depending on the `null_resource` which install them.

### Why
This can *potentially* cause the installation to happen *after* the zip
is created, which therefore will miss these dependences.


### Ticket
Possible solution to https://trello.com/c/MpBnZkQx/548-lambda-function-i-o-error-5