### PR TITLE
CP-API role can s3:PutEncryptionConfiguration

### DIFF
--- a/infra/terraform/modules/control_panel_api/role.tf
+++ b/infra/terraform/modules/control_panel_api/role.tf
@@ -36,7 +36,8 @@ resource "aws_iam_policy" "control_panel_api" {
       "Effect": "Allow",
       "Action": [
         "s3:CreateBucket",
-        "s3:PutBucketLogging"
+        "s3:PutBucketLogging",
+        "s3:PutEncryptionConfiguration"
       ],
       "Resource": [
         "arn:aws:s3:::${var.env}-*"


### PR DESCRIPTION
### What

CP-API will create S3 bucket with encryption enabled by default.
In order to do this, it will make a request to 'PUT Bucket encryption'
which requires the `s3:PutEncryptionConfiguration` permission.

**NOTE**: This may not be necessary as according to the documentation the bucket
owner has this permission, but can't see who is the owner from the AWS console.

### See
https://docs.aws.amazon.com/AmazonS3/latest/dev/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources

### Part of ticket
https://trello.com/c/NJsrt6fe/584-2-enable-bucket-level-encryption-for-user-created-buckets
