### PR TITLE
Control Panel IAM role can read/write roles' inline policies

### DIFF
--- a/infra/terraform/modules/control_panel_api/role.tf
+++ b/infra/terraform/modules/control_panel_api/role.tf
@@ -110,6 +110,28 @@ resource "aws_iam_policy" "control_panel_api" {
         "arn:aws:iam::${var.account_id}:role/${var.env}_user_*",
         "arn:aws:iam::${var.account_id}:role/${var.env}_app_*"
       ]
+    },
+    {
+      "Sid": "CanReadRolesInlinePolicies",
+      "Effect": "Allow",
+      "Action": [
+        "iam:GetRolePolicy"
+      ],
+      "Resource": [
+        "arn:aws:iam::${var.account_id}:role/${var.env}_user_*",
+        "arn:aws:iam::${var.account_id}:role/${var.env}_app_*"
+      ]
+    },
+    {
+      "Sid": "CanUpdateRolesInlinePolicies",
+      "Effect": "Allow",
+      "Action": [
+        "iam:PutRolePolicy"
+      ],
+      "Resource": [
+        "arn:aws:iam::${var.account_id}:role/${var.env}_user_*",
+        "arn:aws:iam::${var.account_id}:role/${var.env}_app_*"
+      ]
     }
   ]
 }


### PR DESCRIPTION
This is necessary for IAM roles revamp to work:

https://github.com/ministryofjustice/analytics-platform-control-panel/pull/88

After this changes CP-API will need to read and write IAM roles' inline policies which requires `iam:GetRolePolicy` and `iam:PutRolePolicy`.

### Ticket
Part of https://trello.com/c/2nuxrwiq/586-5-iam-policies-change-from-1-per-bucket-to-1-per-user