### PR TITLE
(TEMPORARY) CP-API role permission to read/update users roles trust policies

### DIFF
--- a/infra/terraform/modules/control_panel_api/role.tf
+++ b/infra/terraform/modules/control_panel_api/role.tf
@@ -132,6 +132,17 @@ resource "aws_iam_policy" "control_panel_api" {
         "arn:aws:iam::${var.account_id}:role/${var.env}_user_*",
         "arn:aws:iam::${var.account_id}:role/${var.env}_app_*"
       ]
+    },
+    {
+      "Sid": "TemporaryForOIDCMigration",
+      "Effect": "Allow",
+      "Action": [
+        "iam:GetRole",
+        "iam:UpdateAssumeRolePolicy"
+      ],
+      "Resource": [
+        "arn:aws:iam::${var.account_id}:role/${var.env}_user_*"
+      ]
     }
   ]
 }


### PR DESCRIPTION
### What
The [migration which adds the OIDC statement to the users' roles trust policies](https://github.com/ministryofjustice/analytics-platform-control-panel/pull/90) will need the `iam:GetRole` and `iam:UpdateAssumeRolePolicy` permissions to read/update them.

**NOTE**: This will be needed *only* before running the migration.

After running the migration we can remove them.
In fact, there is no point in merging this, better just apply off this branch.

### Part of ticket
https://trello.com/c/Vy7ImBcn/602-4-sso-aws-federated-login-user-roles-migration
