### PR TITLE
Add s3:PutBucketTagging

### DIFF
--- a/infra/terraform/modules/control_panel_api/role.tf
+++ b/infra/terraform/modules/control_panel_api/role.tf
@@ -37,6 +37,7 @@ resource "aws_iam_policy" "control_panel_api" {
       "Action": [
         "s3:CreateBucket",
         "s3:PutBucketLogging",
+        "s3:PutBucketTagging",
         "s3:PutEncryptionConfiguration"
       ],
       "Resource": [


### PR DESCRIPTION
## What

This enables the new call to put bucket tagging on a 'data warehouse' bucket.

Related to PR on api https://github.com/ministryofjustice/analytics-platform-control-panel/pull/93