### PR TITLE
Add permission to list IAM policies to control_panel IAM role

### DIFF
--- a/infra/terraform/modules/control_panel_api/role.tf
+++ b/infra/terraform/modules/control_panel_api/role.tf
@@ -135,6 +135,16 @@ resource "aws_iam_policy" "control_panel_api" {
       ]
     },
     {
+      "Sid": "CanListPoliciesForLambdaMigration",
+      "Effect": "Allow",
+      "Action": [
+        "iam:ListPolicies"
+      ],
+      "Resource": [
+        "arn:aws:iam::${var.account_id}:*"
+      ]
+    },
+    {
       "Sid": "TemporaryForOIDCMigration",
       "Effect": "Allow",
       "Action": [


### PR DESCRIPTION
### What
Added permission to `iam:ListPolicies` to `control_panel_api` IAM role

### Why
This is needed by the [migration](https://github.com/ministryofjustice/analytics-platform-control-panel/pull/109/files#diff-7c3ac2e9db789dd8ece232021649f51aR38) which reads IAM policies and
creates the corresponding S3 buckets in the Control Panel API DB.

### See
- [migration PR](https://github.com/ministryofjustice/analytics-platform-control-panel/pull/109)
- [IAM documentation at iam.cloudonaut.io](https://iam.cloudonaut.io/reference/iam.html)

### TODO
- [X] Apply in `dev`
- [x] Test in `dev` to see if migration can read IAM policies
- [ ] Apply in `alpha`

### Part of ticket
https://trello.com/c/Me2RD6ek/696-5-script-that-copies-data-access-permissions-from-existing-lambda-created-policies-to-to-s3-access-inline-policy-and-adds-these