### PR TITLE
Enable backups for CP-API database

### DIFF
--- a/infra/terraform/modules/control_panel_api/db.tf
+++ b/infra/terraform/modules/control_panel_api/db.tf
@@ -20,12 +20,15 @@ resource "aws_db_instance" "control_panel_db" {
     storage_type = "${var.storage_type}"
     allocated_storage = "${var.allocated_storage}"
     engine = "postgres"
-    engine_version = "9.6.2"
+    engine_version = "9.6.6"
     instance_class = "db.t2.micro"
     name = "controlpanel"
     username = "${var.db_username}"
     password = "${var.db_password}"
     db_subnet_group_name = "${aws_db_subnet_group.control_panel_db.name}"
     vpc_security_group_ids = ["${aws_security_group.control_panel_db.*.id}"]
-    skip_final_snapshot = true
+    backup_retention_period = 35
+    backup_window = "22:00-23:59"
+    skip_final_snapshot = false
+    maintenance_window = "Sat:01:00-Sat:03:00"
 }


### PR DESCRIPTION
- Set retention period to 35 days
- Set backup window between 10pm and midnight (everyday)
- Set maintenance window Saturday night between 1am and 3am
- Do **not** skip final snapshot. When an RDS instance is destroyed
  (by accident of for whatever reason) AWS will take a final snapshot.
  This can be really useful.

**NOTE**: I also set PostgreSQL version to 9.6.6 as this is the version which
the RDS instance is actually using!