### PR TITLE
[WIP DO NOT MERGE] Create EBS etcd SnapShots

### DIFF
--- a/infra/terraform/global/assets/create_etcd_ebs_snapshot/README.md
+++ b/infra/terraform/global/assets/create_etcd_ebs_snapshot/README.md
@@ -1,0 +1,38 @@
+## Create K8s EBS etcd volume snapshots Lambda function
+=======================================================
+
+Prerequisites
+-------------
+
+You'll need a working [Go](www.golang.org/doc/) environment to build a distribution
+
+For working with the [Go](www.golang.org) runtime in AWS Lambda. See [lambda-go-how-to-create-deployment-package](https://docs.aws.amazon.com/lambda/latest/dg/lambda-go-how-to-create-deployment-package.html)
+
+To Build and Deploy
+---------
+
+The Lambda execution environment uses a Linux kernel, so you'll need to build the binary for linux
+```
+GOOS=linux go build create_etcd_ebs_snapshot.go 
+
+```
+
+Once you have built a distribution with the command above see [Lambda_EBS_Module](../../../modules/lambda_ebs_mgmt/README.md)
+for an example on how to deploy
+
+To Test
+-------
+
+__Optionally__ set filter tags to filter ec2 instances.  My filter below states that I only want to target 
+ec2 instances with a tag that matches __key__ `aws:autoscaling:groupName` with the __value__ `webservers`.
+
+```
+export INSTANCE_KEY=aws:autoscaling:groupName
+export INSTANCE_VALUE=webservers
+```
+
+__Note__: If testing locally, you may need to set the __region__ in your `~/.aws/config` file or by setting 
+`AWS_REGION` environment variable.
+
+Test by running
+`go run create_etcd_ebs_snapshot.go`

--- a/infra/terraform/global/assets/create_etcd_ebs_snapshot/create_etcd_ebs_snapshot.go
+++ b/infra/terraform/global/assets/create_etcd_ebs_snapshot/create_etcd_ebs_snapshot.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/aws"
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"os"
+	"log"
+)
+
+var (
+	connection = ec2.New(session.New())
+)
+
+
+func main() {
+
+	instanceKeyFilter   := os.Getenv("INSTANCE_KEY")
+	instanceValueFilter := os.Getenv("INSTANCE_VALUE")
+
+	// Filter instances with role set to master
+	instanceInput := &ec2.DescribeInstancesInput{
+		Filters: []*ec2.Filter{
+			{
+				Name: 	aws.String(fmt.Sprintf("tag:%s", instanceKeyFilter )),
+				Values: []*string{ aws.String(instanceValueFilter)},
+			},
+		},
+	}
+
+	// A reservation corresponds to a command to start instances
+	// A reservation is what you do to provision instances, while an instance is what you get
+	reservation, err := connection.DescribeInstances(instanceInput)
+	if err != nil {
+		log.Fatal(err.Error())
+	}
+
+	// Iterate over reservations
+	for index := range reservation.Reservations {
+
+		// Iterate reservations to access ec2 instances
+		for _, inst := range reservation.Reservations[index].Instances {
+
+			// Iterate over each instance's block device metadata
+			for _, blk := range inst.BlockDeviceMappings {
+
+				// Exclude root volumes.  Root volumes have "Delete on termination" set to true mostly
+				rootDevice := *blk.Ebs.DeleteOnTermination
+
+				if rootDevice != true {
+					vol_id := blk.Ebs.VolumeId
+
+					snapshotInput := &ec2.CreateSnapshotInput{
+						VolumeId: vol_id,
+					}
+
+					// Perform ebs snapshot operation
+					snapIt, err := connection.CreateSnapshot(snapshotInput)
+					if err != nil {
+						if aerr, ok := err.(awserr.Error); ok {
+							switch aerr.Code() {
+							default:
+								fmt.Println(aerr.Error())
+							}
+						} else {
+							// Print the error, cast err to awserr.Error to get the Code and
+							// Message from an error.
+							fmt.Println(err.Error())
+						}
+						return
+					}
+					// Print result
+					fmt.Println(snapIt)
+
+					volTagsInput := &ec2.DescribeTagsInput{
+						Filters:	[]*ec2.Filter{
+							{
+								Name:	aws.String("resource-id"),
+								Values: []*string{
+									aws.String(*vol_id),
+								},
+							},
+						},
+					}
+
+					// Get the volume's tags
+					getVolumesTags, err := connection.DescribeTags(volTagsInput)
+					if err != nil {
+						if aerr, ok := err.(awserr.Error); ok {
+							switch aerr.Code() {
+							default:
+								fmt.Println(aerr.Error())
+							}
+						} else {
+							// Print the error, cast err to awserr.Error to get the Code and
+							// Message from an error.
+							fmt.Println(err.Error())
+						}
+						return
+					}
+
+					snapShotID   := *snapIt.SnapshotId
+					instanceName := *inst.Tags[1].Value
+					deviceName   := *blk.DeviceName
+					volumeName   := *getVolumesTags.Tags[1].Value
+
+					tagsInput := &ec2.CreateTagsInput{
+						Resources: []*string{
+							aws.String(snapShotID),
+						},
+						Tags: []*ec2.Tag{
+							{
+								Key:   aws.String("Instance_Name"),
+								Value: aws.String(instanceName),
+
+							},
+							{
+								Key:   aws.String("Device_Name"),
+								Value: aws.String(deviceName),
+							},
+							{
+								Key:   aws.String("Name"),
+								Value: aws.String(volumeName),
+							},
+						},
+					}
+
+					// Finally tag snapshot with instance ID, Device designation and Volume name
+					tagIt, err := connection.CreateTags(tagsInput)
+					if err != nil {
+						if aerr, ok := err.(awserr.Error); ok {
+							switch aerr.Code() {
+							default:
+								fmt.Println(aerr.Error())
+							}
+						} else {
+							// Print the error, cast err to awserr.Error to get the Code and
+							// Message from an error.
+							fmt.Println(err.Error())
+						}
+						return
+					}
+					fmt.Println(tagIt)
+				}
+			}
+		}
+	}
+}

--- a/infra/terraform/global/assets/create_etcd_ebs_snapshot/lambda_create_snapshot_policy.json
+++ b/infra/terraform/global/assets/create_etcd_ebs_snapshot/lambda_create_snapshot_policy.json
@@ -1,0 +1,26 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": ["logs:*"],
+      "Resource": "arn:aws:logs:*:*:*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": "ec2:Describe*",
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateSnapshot",
+        "ec2:ModifySnapshotAttribute",
+        "ec2:ResetSnapshotAttribute",
+        "ec2:DescribeTags",
+        "ec2:CreateTags"
+      ],
+      "Resource": ["*"]
+    }
+  ]
+}

--- a/infra/terraform/modules/lambda_ebs_mgmt/README.md
+++ b/infra/terraform/modules/lambda_ebs_mgmt/README.md
@@ -1,0 +1,58 @@
+## Lambda Ebs Management 
+====================
+
+Used to schedule ebs tasks 
+
+Module Input Variables
+----------------------
+
+- `lambda_function_name` - Name for Lambda function
+- `lambda_runtime` - A [valid](http://docs.aws.amazon.com/cli/latest/reference/lambda/create-function.html#options) Lambda runtime environment. Defaults to `go1.x`
+- `zipfile` - Path to zip archive containing Lambda function
+- `handler` - The entrypoint into your Lambda function, in the form of `filename.function_name`. For `Golang` this must match `lambda_function_name`
+- `schedule_expression` - A [valid rate or cron expression](http://docs.aws.amazon.com/lambda/latest/dg/tutorial-scheduled-events-schedule-expressions.html)
+- `source_code_hash` - The base64 encoded sha256 hash of the archive file - see TF [archive file provider](https://www.terraform.io/docs/providers/archive/d/archive_file.html)
+- `timeout` - (optional) The amount of time your Lambda Function has to run in seconds. Defaults to 3. See [Limits](https://docs.aws.amazon.com/lambda/latest/dg/limits.html)
+- `enabled` - (optional) Boolean expression. If false, the lambda function and the cloudwatch schedule are not set. Defaults to `true`.
+- `instance_tag_key` - (optional) The key of the tag to filter instances on
+- `instance_tag_value` - (optional) The value of the tag to filter instances
+- `lambda_policy` - The IAM policy document.  Usually JSON 
+
+Usage 
+-----
+
+```
+data "template_file" "lambda_create_snapshot_policy" {
+  template = "${file("assets/create_etcd_ebs_snapshot/lambda_create_snapshot_policy.json")}"
+}
+
+data "archive_file" "kubernetes_etcd_ebs_snapshot_code" {
+  source_file = "assets/create_etcd_ebs_snapshot/create_etcd_ebs_snapshot"
+  output_path = "assets/create_etcd_ebs_snapshot/create_etcd_ebs_snapshot.zip"
+  type        = "zip"
+}
+
+module "kubernetes_etcd_ebs_snapshot" {
+  source               = "../modules/lambda_ebs_mgmt"
+  lambda_function_name = "create_etcd_ebs_snapshot"
+  zipfile              = "assets/create_etcd_ebs_snapshot/create_etcd_ebs_snapshot.zip"
+  handler              = "create_etcd_ebs_snapshot"
+  source_code_hash     = "${data.archive_file.kubernetes_etcd_ebs_snapshot_code.output_base64sha256}"
+  instance_tag_key     = "k8s.io/role/master"
+  instance_tag_value   = "1"
+  lamda_policy         = "${data.template_file.lambda_create_snapshot_policy.rendered}"
+}
+```
+
+```
+terraform plan -target=module.kubernetes_etcd_ebs_snapshot
+
+
+terraform apply -target=module.kubernetes_etcd_ebs_snapshot
+
+```
+
+Outputs
+-------
+
+None yet

--- a/infra/terraform/modules/lambda_ebs_mgmt/cloudwatch.tf
+++ b/infra/terraform/modules/lambda_ebs_mgmt/cloudwatch.tf
@@ -1,0 +1,14 @@
+# CloudWatch event rule to schedule event
+resource "aws_cloudwatch_event_rule" "lambda_cloud_watch_rule" {
+  name                = "${var.lambda_function_name}"
+  schedule_expression = "${var.schedule_expression}"
+  count               = "${var.enabled}"
+}
+
+# CloudWatch event target to set rule target to lambda function
+resource "aws_cloudwatch_event_target" "lambda_cloud_watch_target" {
+  target_id = "${var.lambda_function_name}"
+  arn       = "${aws_lambda_function.lambda_function.arn}"
+  rule      = "${aws_cloudwatch_event_rule.lambda_cloud_watch_rule.name}"
+  count     = "${var.enabled}"
+}

--- a/infra/terraform/modules/lambda_ebs_mgmt/iam.tf
+++ b/infra/terraform/modules/lambda_ebs_mgmt/iam.tf
@@ -1,0 +1,28 @@
+# Assume role policy to allow lambda to assume role
+data "aws_iam_policy_document" "lambda_snapshot_assume" {
+  "statement" {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      identifiers = ["lambda.amazonaws.com"]
+      type = "Service"
+    }
+  }
+}
+
+# Lambda policy to attach to lambda_role
+resource "aws_iam_policy" "lambda_policy" {
+  policy = "${var.lamda_policy}"
+}
+
+# The role which the lambda service will assume
+resource "aws_iam_role" "lambda_role" {
+  name               = "${var.lambda_function_name}"
+  assume_role_policy = "${data.aws_iam_policy_document.lambda_snapshot_assume.json}"
+}
+
+# Attaching the lambda_policy to ebs_create_snapshot role
+resource "aws_iam_role_policy_attachment" "lambda_snapshot_attatchment" {
+  policy_arn = "${aws_iam_policy.lambda_policy.arn}"
+  role       = "${aws_iam_role.lambda_role.name}"
+}

--- a/infra/terraform/modules/lambda_ebs_mgmt/lambda.tf
+++ b/infra/terraform/modules/lambda_ebs_mgmt/lambda.tf
@@ -1,0 +1,27 @@
+# Create the Lambda function with environment variables for filtering or config
+resource "aws_lambda_function" "lambda_function" {
+  function_name    = "${var.lambda_function_name}"
+  filename         = "${var.zipfile}"
+  handler          = "${var.handler}"
+  role             = "${aws_iam_role.lambda_role.arn}"
+  runtime          = "${var.lambda_runtime}"
+  source_code_hash = "${var.source_code_hash}"
+  count            = "${var.enabled}"
+  timeout          = "${var.timeout}"
+  environment {
+    variables {
+      INSTANCE_KEY   = "${var.instance_tag_key}"
+      INSTANCE_VALUE = "${var.instance_tag_value}"
+    }
+  }
+}
+
+# Lambda permission to allow cloudwatch to invoke lambda function
+resource "aws_lambda_permission" "lambda_permission" {
+  action        = "lambda:InvokeFunction"
+  function_name = "${aws_lambda_function.lambda_function.function_name}"
+  principal     = "events.amazonaws.com"
+  statement_id  = "AllowExecutionFromCloudWatch"
+  count         = "${var.enabled}"
+  source_arn    = "${aws_cloudwatch_event_rule.lambda_cloud_watch_rule.arn}"
+}

--- a/infra/terraform/modules/lambda_ebs_mgmt/variables.tf
+++ b/infra/terraform/modules/lambda_ebs_mgmt/variables.tf
@@ -1,0 +1,45 @@
+
+variable "lambda_function_name" {
+  description = "The default name of all resources"
+}
+
+variable "lambda_runtime" {
+  default     = "go1.x"
+  description = "Runtime language for lambda function. See: https://docs.aws.amazon.com/lambda/latest/dg/API_CreateFunction.html#SSS-CreateFunction-request-Runtime"
+}
+
+variable "handler" {
+  description = "Entrypoint filename. For `Golang` this must match `lambda_function_name`"
+}
+
+variable "zipfile" {
+  description = "Path to zip file containing code"
+}
+
+variable "enabled" {
+  default = true
+}
+
+variable "timeout" {
+  default = 3
+}
+
+variable "schedule_expression" {
+  default = "rate(1 day)"
+}
+
+variable "source_code_hash" {}
+
+variable "instance_tag_key" {
+  default     = ""
+  description = "The key of the tag to filter instances on"
+}
+
+variable "instance_tag_value" {
+  default     = ""
+  description = "The value of the tag to filter instances"
+}
+
+variable "lamda_policy" {
+  description = "The IAM policy document.  Usually JSON"
+}


### PR DESCRIPTION
I'm going to split this into two PRs and refactor.  Just looking for sanity check on the function itslef atm
https://github.com/ministryofjustice/analytics-platform-ops/pull/137/files#diff-d47f26c10ff14ff0c72dcd0af6878036



## What
Create ebs Snapshots of etcd volumes

Frequency: daily

Targeted instances can be filtered using the `instance_tag_key` and
`instance_tag_value` params.



## How to review

1. Login to aws [console](https://us-east-1.signin.aws.amazon.com/oauth?SignatureVersion=4&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAJMOATPLHVSJ563XQ&X-Amz-Date=2017-12-06T09%3A54%3A40.100Z&X-Amz-Signature=bd5db0db4d4c35fb5ac8dbe3c6ff85282305f21aa4f8af0fdad2237f7cbda4a9&X-Amz-SignedHeaders=host&client_id=arn%3Aaws%3Aiam%3A%3A015428540659%3Auser%2Fhomepage&redirect_uri=https%3A%2F%2Fconsole.aws.amazon.com%2Fconsole%2Fhome%3Fstate%3DhashArgs%2523%26isauthcode%3Dtrue&response_type=code&state=hashArgs%23)
2. View Cloud watch [Logs](https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#logStream:group=/aws/lambda/create_etcd_ebs_snapshot;streamFilter=typeLogStreamPrefix)
3. Sanity check Function by following [README](https://github.com/ministryofjustice/analytics-platform-ops/tree/ebs-backups/infra/terraform/global/assets/create_etcd_ebs_snapshot)

