### PR TITLE
Granting CP-API IAM role permission to list/delete inline policies

### DIFF
--- a/infra/terraform/modules/control_panel_api/role.tf
+++ b/infra/terraform/modules/control_panel_api/role.tf
@@ -107,7 +107,9 @@ resource "aws_iam_policy" "control_panel_api" {
       "Action": [
         "iam:DeleteRole",
         "iam:ListAttachedRolePolicies",
-        "iam:DetachRolePolicy"
+        "iam:ListRolePolicies",
+        "iam:DetachRolePolicy",
+        "iam:DeleteRolePolicy"
       ],
       "Resource": [
         "arn:aws:iam::${var.account_id}:role/${var.env}_user_*",


### PR DESCRIPTION
### What/Why
CP-API's IAM role can now perform the following operations:
- [`iam:ListRolePolicies`](https://iam.cloudonaut.io/reference/iam/ListRolePolicies.html) - to lists the names of the inline policies that are embedded in the specified IAM role.
- [`iam:DeleteRolePolicy`](https://iam.cloudonaut.io/reference/iam/DeleteRolePolicy.html) - Deletes the specified inline policy that is embedded in the specified IAM role.

This is required by the CP-API to delete all the inline policies
of a user/app IAM role before deleting it.

Delete users in the CP didn't work because now most IAM roles have the
`s3-access` inline policy.

### Related PR

https://github.com/ministryofjustice/analytics-platform-control-panel/pull/175

### Part of ticket

https://trello.com/c/04FsXha3/984-cant-delete-users

### GitHub Issue

https://github.com/ministryofjustice/analytics-platform/issues/33

### TODO
- [ ] Apply in `dev`
- [ ] Apply in `alpha`