### PR TITLE
Lambda Module environment variables

### DIFF
--- a/infra/terraform/modules/lambda_mgmt/lambda.tf
+++ b/infra/terraform/modules/lambda_mgmt/lambda.tf
@@ -10,10 +10,7 @@ resource "aws_lambda_function" "lambda_function" {
   timeout          = "${var.timeout}"
 
   environment {
-    variables {
-      "${var.env_name_1}" = "${var.env_value_1}"
-      "${var.env_name_2}" = "${var.env_value_2}"
-    }
+    variables = "${var.environment_variables}"
   }
 }
 

--- a/infra/terraform/modules/lambda_mgmt/variables.tf
+++ b/infra/terraform/modules/lambda_mgmt/variables.tf
@@ -29,26 +29,12 @@ variable "schedule_expression" {
 
 variable "source_code_hash" {}
 
-variable "env_name_1" {
-  default     = ""
-  description = "The key of an environment variable"
-}
-
-variable "env_value_1" {
-  default     = ""
-  description = "The value of an environment variable"
-}
-
-variable "env_name_2" {
-  default     = ""
-  description = "The key of an environment variable"
-}
-
-variable "env_value_2" {
-  default     = ""
-  description = "The value of an environment variable"
-}
-
 variable "lamda_policy" {
   description = "The IAM policy document.  Usually JSON"
+}
+
+variable "environment_variables" {
+  type        = "map"
+  default     = {}
+  description = "The environment variables for you lambda function"
 }


### PR DESCRIPTION
Forgot to push these changes with the last merge.  

Defining the terraform variables block at invocation allows the module to be more generic as
terraform cannot interpolate terraform variables as keys to environment variables.

The module has an empty map passed to the environment block which is expecting a map.

The map will then be populated when the module is invoked elsewhere with there own custom environment variables.  See the [README](https://github.com/ministryofjustice/analytics-platform-ops/blob/e36f76bbf00dc5bb6a469a72dcaa1b7b4a0ab8ed/infra/terraform/modules/lambda_mgmt/README.md) for an example

This has already been deployed and works.