### PR TITLE
Invalid Mapping

### DIFF
--- a/infra/elasticsearch/templates/cloudtrail.json
+++ b/infra/elasticsearch/templates/cloudtrail.json
@@ -23,7 +23,7 @@
         {
           "geo_point_fields": {
             "match": "*",
-            "match_mapping_type": "geo_point",
+            "match_mapping_type": "object",
             "mapping": {
               "type": "geo_point",
               "doc_values": true

--- a/infra/elasticsearch/templates/s3logs.json
+++ b/infra/elasticsearch/templates/s3logs.json
@@ -23,7 +23,7 @@
         {
           "geo_point_fields": {
             "match": "*",
-            "match_mapping_type": "geo_point",
+            "match_mapping_type": "object",
             "mapping": {
               "type": "geo_point",
               "doc_values": true


### PR DESCRIPTION
These templates are using an invalid type to map data to.

Supported types are strings,floats,booleans,object,etc....

__Object__ seemed the best fit as it catches all.

This has been deployed

