### PR TITLE
Elasticsearch Console

### DIFF
--- a/infra/elasticsearch/README.md
+++ b/infra/elasticsearch/README.md
@@ -4,7 +4,7 @@ We use a hosted service provided by [elastic](https://www.elastic.co) which can 
 
 #### Administration
 
-The easiest way to administer elasticsearch itself is via the integrated __kopf__ console which can be accessed once logged in to the [console](https://cloud.elastic.co/#/authentication/login/)
+The easiest way to administer elasticsearch itself is via the integrated __API Console__ which can be accessed once logged in to the [console](https://cloud.elastic.co/#/authentication/login/)
 
 #### Backups
 
@@ -12,7 +12,7 @@ The easiest way to administer elasticsearch itself is via the integrated __kopf_
 
 You'll need a repository to store snapshots.  For this we use an s3 backend
 
-From __kopf__
+From the __API Console__
 
 ```
 PUT /_snapshot/repository 
@@ -32,7 +32,7 @@ PUT /_snapshot/repository
 
 With an existing repository, you can now create snapshots
 
-From __kopf__
+From the __API Console__
 
 ```
 PUT /_snapshot/repository/pre-upgrade-01-01-1970 {
@@ -41,4 +41,16 @@ PUT /_snapshot/repository/pre-upgrade-01-01-1970 {
   "compress": "true",
   "server_side_encryption": "true"
 }
+```
+
+##### List Templates
+
+```
+GET /_cat/templates?v&s=name
+```
+
+##### List Indices
+
+```
+GET /_cat/indices?v
 ```


### PR DESCRIPTION
Elastic have removed __kopf__ in favor of the __API Console__ (Not
happy about that)

Updating docs to reflect the change.

Adding __list__ queries which are useful to have to hand
