### PR TITLE
(S) Airflow's RDS instances with more memory

### DIFF
--- a/infra/terraform/environments/alpha/main.tf
+++ b/infra/terraform/environments/alpha/main.tf
@@ -121,10 +121,11 @@ module "airflow_storage_efs_volume" {
 module "airflow_db" {
   source = "../../modules/postgres_db"
 
-  instance_name = "${var.env}-airflow"
-  db_name       = "airflow"
-  username      = "${var.airflow_db_username}"
-  password      = "${var.airflow_db_password}"
+  instance_name  = "${var.env}-airflow"
+  instance_class = "db.m3.medium"
+  db_name        = "airflow"
+  username       = "${var.airflow_db_username}"
+  password       = "${var.airflow_db_password}"
 
   vpc_id                 = "${module.aws_vpc.vpc_id}"
   node_security_group_id = "${module.aws_vpc.extra_node_sg_id}"

--- a/infra/terraform/environments/dev/main.tf
+++ b/infra/terraform/environments/dev/main.tf
@@ -120,10 +120,11 @@ module "airflow_storage_efs_volume" {
 module "airflow_db" {
   source = "../../modules/postgres_db"
 
-  instance_name = "${var.env}-airflow"
-  db_name       = "airflow"
-  username      = "${var.airflow_db_username}"
-  password      = "${var.airflow_db_password}"
+  instance_name  = "${var.env}-airflow"
+  instance_class = "db.m3.medium"
+  db_name        = "airflow"
+  username       = "${var.airflow_db_username}"
+  password       = "${var.airflow_db_password}"
 
   vpc_id                 = "${module.aws_vpc.vpc_id}"
   node_security_group_id = "${module.aws_vpc.extra_node_sg_id}"


### PR DESCRIPTION
What
====
Airflow DB instance types were `t2.micro` (512 MiB of memory).

Now using `db.m3.medium` which has 3.75 GiB (on both `dev` and `alpha`).

See: https://aws.amazon.com/rds/instance-types/

Why
===
Even with relatively trivial DAGs with 30-60 tasks running concurrently
we were seeing some errors relative to DB connections.

It seemed like the DB dropped connections after ~32.
The `max_connections` depends on the amount of memory the RDS instance has,
specifically:

max_connections = DBInstanceClassMemory / 12582880

So 3.75GiB will give us a `max_connections` of ~320.

See: https://serverfault.com/a/862418
