### PR TITLE
Concourse list-roles user

### DIFF
--- a/infra/terraform/global/main.tf
+++ b/infra/terraform/global/main.tf
@@ -66,6 +66,12 @@ module "hmpps_oasys_upload_user" {
   system_name       = "oasys"
 }
 
+module "mojanalytics_concourse_iam_list_roles_user" {
+  source      = "../modules/iam_list_roles"
+  org_name    = "mojanalytics"
+  system_name = "concourse"
+}
+
 // Empty Placeholder variable to be overrided when using the lambda_mgmt module
 variable "environment_variables" {
   type = "map"

--- a/infra/terraform/global/outputs.tf
+++ b/infra/terraform/global/outputs.tf
@@ -57,3 +57,11 @@ output "hmpps_oasys_access_key_id" {
 output "hmpps_oasys_access_key_secret" {
   value = "${module.hmpps_oasys_upload_user.access_key_secret}"
 }
+
+output "mojanalytics_concourse_iam_list_roles_access_key_id" {
+  value = "${module.mojanalytics_concourse_iam_list_roles_user.access_key_id}"
+}
+
+output "mojanalytics_concourse_iam_list_roles_access_key_secret" {
+  value = "${module.mojanalytics_concourse_iam_list_roles_user.access_key_secret}"
+}

--- a/infra/terraform/modules/iam_list_roles/iam.tf
+++ b/infra/terraform/modules/iam_list_roles/iam.tf
@@ -1,0 +1,33 @@
+resource "aws_iam_user" "system" {
+  name = "${var.org_name}_${var.system_name}_iam_roles_readonly"
+  path = "/uploaders/${var.org_name}/"
+}
+
+resource "aws_iam_access_key" "system_user" {
+  user = "${aws_iam_user.system.name}"
+}
+
+data "aws_iam_policy_document" "iam_roles_readonly" {
+  statement {
+    actions = [
+      "iam:ListRoles",
+    ]
+
+    effect = "Allow"
+
+    resources = [
+      "*",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "iam_roles_readonly" {
+  name   = "${var.org_name}_${var.system_name}_iam_roles_readonly"
+  path   = "/iam/${var.org_name}/${var.system_name}/"
+  policy = "${data.aws_iam_policy_document.iam_roles_readonly.json}"
+}
+
+resource "aws_iam_user_policy_attachment" "concourse_list_roles" {
+  user       = "${aws_iam_user.system.name}"
+  policy_arn = "${aws_iam_policy.iam_roles_readonly.arn}"
+}

--- a/infra/terraform/modules/iam_list_roles/outputs.tf
+++ b/infra/terraform/modules/iam_list_roles/outputs.tf
@@ -1,0 +1,7 @@
+output "access_key_id" {
+  value = "${aws_iam_access_key.system_user.id}"
+}
+
+output "access_key_secret" {
+  value = "${aws_iam_access_key.system_user.secret}"
+}

--- a/infra/terraform/modules/iam_list_roles/variables.tf
+++ b/infra/terraform/modules/iam_list_roles/variables.tf
@@ -1,0 +1,3 @@
+variable "org_name" {}
+
+variable "system_name" {}


### PR DESCRIPTION



## What

Create a new aws user that has the permission to list roles.

This will be used by concourse, specifically the airflow dags pipeline as it
will check that any roles annotated in a DAG also exist in AWS.

We may later provide a mechanism to automatically create roles based on source
code committed alongside the DAG but for now it's just a check

## How to review

1. `terraform plan`
2. see `4 added, 0 destroyed` in the output
3. `terraform apply`

https://trello.com/c/hmFr3yb8/1270-ci-for-airflow-dags

