### PR TITLE
Imported SES resources for root domain

### DIFF
--- a/infra/terraform/global/main.tf
+++ b/infra/terraform/global/main.tf
@@ -128,4 +128,7 @@ module "kubernetes_prune_ebs_snapshots" {
 
 module "ses_domain" {
   source = "../modules/ses_domain"
+  domain = "${var.xyz_root_domain}"
+
+  aws_route53_zone_id = "${aws_route53_zone.xyz_zone.zone_id}"
 }

--- a/infra/terraform/global/main.tf
+++ b/infra/terraform/global/main.tf
@@ -125,3 +125,7 @@ module "kubernetes_prune_ebs_snapshots" {
   lamda_policy          = "${data.template_file.lambda_prune_ebs_snapshots_policy.rendered}"
   environment_variables = "${var.environment_variables}"
 }
+
+module "ses_domain" {
+  source = "../modules/ses_domain"
+}

--- a/infra/terraform/global/outputs.tf
+++ b/infra/terraform/global/outputs.tf
@@ -14,6 +14,10 @@ output "xyz_root_domain" {
   value = "${var.xyz_root_domain}"
 }
 
+output "xyz_root_domain_ses_identity_arn" {
+  value = "${module.ses_domain.identity_arn}"
+}
+
 output "kops_bucket_name" {
   value = "${var.kops_bucket_name}"
 }

--- a/infra/terraform/modules/ses_domain/inputs.tf
+++ b/infra/terraform/modules/ses_domain/inputs.tf
@@ -1,0 +1,3 @@
+variable "domain" {}
+
+variable "aws_route53_zone_id" {}

--- a/infra/terraform/modules/ses_domain/main.tf
+++ b/infra/terraform/modules/ses_domain/main.tf
@@ -1,3 +1,37 @@
-resource "aws_ses_domain_identity" "root_domain" {
-  domain = "mojanalytics.xyz"
+resource "aws_ses_domain_identity" "domain" {
+  domain = "${var.domain}"
+}
+
+# SES Verification: TXT Record
+resource "aws_route53_record" "amazonses_verification_record" {
+  zone_id = "${var.aws_route53_zone_id}"
+
+  name = "_amazonses.${aws_ses_domain_identity.domain.id}"
+
+  type = "TXT"
+  ttl  = "1800"
+
+  records = [
+    "${aws_ses_domain_identity.domain.verification_token}",
+  ]
+}
+
+resource "aws_ses_domain_identity_verification" "amazonses_verification" {
+  domain = "${aws_ses_domain_identity.domain.id}"
+
+  depends_on = ["aws_route53_record.amazonses_verification_record"]
+}
+
+# SES Verification: DKIM
+resource "aws_ses_domain_dkim" "domain_verification" {
+  domain = "${aws_ses_domain_identity.domain.domain}"
+}
+
+resource "aws_route53_record" "domain_amazonses_dkim_verification_record" {
+  count   = 3
+  zone_id = "${var.aws_route53_zone_id}"
+  name    = "${element(aws_ses_domain_dkim.domain_verification.dkim_tokens, count.index)}._domainkey.${aws_ses_domain_identity.domain.domain}"
+  type    = "CNAME"
+  ttl     = "1800"
+  records = ["${element(aws_ses_domain_dkim.domain_verification.dkim_tokens, count.index)}.dkim.amazonses.com"]
 }

--- a/infra/terraform/modules/ses_domain/main.tf
+++ b/infra/terraform/modules/ses_domain/main.tf
@@ -28,7 +28,7 @@ resource "aws_ses_domain_dkim" "domain_verification" {
 }
 
 resource "aws_route53_record" "domain_amazonses_dkim_verification_record" {
-  count   = 3
+  count   = "${length(aws_ses_domain_dkim.domain_verification.dkim_tokens)}"
   zone_id = "${var.aws_route53_zone_id}"
   name    = "${element(aws_ses_domain_dkim.domain_verification.dkim_tokens, count.index)}._domainkey.${aws_ses_domain_identity.domain.domain}"
   type    = "CNAME"

--- a/infra/terraform/modules/ses_domain/main.tf
+++ b/infra/terraform/modules/ses_domain/main.tf
@@ -1,0 +1,3 @@
+resource "aws_ses_domain_identity" "root_domain" {
+  domain = "mojanalytics.xyz"
+}

--- a/infra/terraform/modules/ses_domain/outputs.tf
+++ b/infra/terraform/modules/ses_domain/outputs.tf
@@ -1,0 +1,3 @@
+output "identity_arn" {
+  value = "${aws_ses_domain_identity.domain.arn}"
+}


### PR DESCRIPTION
The SES resources were created manually in the AWS Console rather than using Terraform.
This PR imports these resources so that they're managed by Terraform.