### PR TITLE
Added SES SMTP user for Airflow

### DIFF
--- a/infra/terraform/modules/ses_smtp_user/inputs.tf
+++ b/infra/terraform/modules/ses_smtp_user/inputs.tf
@@ -1,0 +1,3 @@
+variable "ses_domain_identity_arn" {}
+
+variable "username" {}

--- a/infra/terraform/modules/ses_smtp_user/main.tf
+++ b/infra/terraform/modules/ses_smtp_user/main.tf
@@ -1,0 +1,28 @@
+resource "aws_iam_user" "smtp_user" {
+  name = "${var.username}"
+}
+
+resource "aws_iam_access_key" "access_key" {
+  user = "${aws_iam_user.smtp_user.name}"
+}
+
+resource "aws_iam_user_policy" "smtp_user_policy" {
+  name = "${aws_iam_user.smtp_user.name}_policy"
+  user = "${aws_iam_user.smtp_user.name}"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+        "Action": [
+            "ses:SendRawEmail",
+            "ses:SendEmail"
+        ],
+        "Effect": "Allow",
+        "Resource": "${var.ses_domain_identity_arn}"
+    }
+  ]
+}
+EOF
+}

--- a/infra/terraform/modules/ses_smtp_user/outputs.tf
+++ b/infra/terraform/modules/ses_smtp_user/outputs.tf
@@ -1,0 +1,3 @@
+output "password" {
+  value = "${aws_iam_access_key.access_key.ses_smtp_password}"
+}

--- a/infra/terraform/platform/main.tf
+++ b/infra/terraform/platform/main.tf
@@ -120,6 +120,14 @@ module "airflow_db" {
   subnet_ids             = "${module.aws_vpc.storage_subnet_ids}"
 }
 
+module "airflow_smtp_user" {
+  source = "../modules/ses_smtp_user"
+
+  ses_domain_identity_arn = "${data.terraform_remote_state.base.xyz_root_domain_ses_identity_arn}"
+
+  username = "${terraform.workspace}_airflow_smtp_user"
+}
+
 module "cert_manager" {
   source           = "../modules/ec2_cert_manager_role"
   role_name        = "${terraform.workspace}-cert-manager"

--- a/infra/terraform/platform/outputs.tf
+++ b/infra/terraform/platform/outputs.tf
@@ -6,6 +6,10 @@ output "airflow_efs_host" {
   value = "${module.airflow_storage_efs_volume.dns_name}"
 }
 
+output "airflow_smtp_password" {
+  value = "${module.airflow_smtp_user.password}"
+}
+
 output "control_panel_api_db_host" {
   value = "${module.control_panel_api.db_host}"
 }


### PR DESCRIPTION
The `ses_smtp_user` can be used to create an IAM user with
permission to send emails from the specified SES Domain Identity.

**NOTE**: The SMTP password for the user is not specified but it's
an output of the IAM Access Key associated with the IAM user

Luckily terraform's [`iam_access_key` has an attribute to get hold of the SMTP password](https://www.terraform.io/docs/providers/aws/r/iam_access_key.html#ses_smtp_password) without having to do anything weird.


Ticket: https://trello.com/c/tTZ1DG3y/1322-fix-airflow-email-notifications