### PR TITLE
update data_upload_user Terraform module for prison self service user

### DIFF
--- a/infra/terraform/global/main.tf
+++ b/infra/terraform/global/main.tf
@@ -66,6 +66,14 @@ module "hmpps_oasys_upload_user" {
   system_name       = "oasys"
 }
 
+module "hmpps_prisonss_upload_user" {
+  source = "../modules/data_upload_user"
+
+  upload_bucket_arn = "${aws_s3_bucket.uploads.arn}"
+  org_name          = "hmpps"
+  system_name       = "prison-selfservice"
+}
+
 module "mojanalytics_concourse_iam_list_roles_user" {
   source      = "../modules/iam_list_roles"
   org_name    = "mojanalytics"

--- a/infra/terraform/global/outputs.tf
+++ b/infra/terraform/global/outputs.tf
@@ -69,3 +69,11 @@ output "mojanalytics_concourse_iam_list_roles_access_key_id" {
 output "mojanalytics_concourse_iam_list_roles_access_key_secret" {
   value = "${module.mojanalytics_concourse_iam_list_roles_user.access_key_secret}"
 }
+
+output "hmpps_prisonss_access_key_id" {
+  value = "${module.hmpps_prisonss_upload_user.access_key_id}"
+}
+
+output "hmpps_nomis_access_key_secret" {
+  value = "${module.hmpps_prisonss_upload_user.access_key_secret}"
+}


### PR DESCRIPTION
This is to onboard prison self service data on Analytical platform. 

Merging this PR will create a new user in AWS that provides write only access to 'mojap-land/hmpps/prison-selfservice' bucket. 

## What is changed in the PR

This has 2 changes in main.tf and output.tf 