### PR TITLE
upated iam s3 policy to write files into MOJAP-LAND

### DIFF
--- a/infra/terraform/modules/data_upload_user/iam.tf
+++ b/infra/terraform/modules/data_upload_user/iam.tf
@@ -17,7 +17,8 @@ data "aws_iam_policy_document" "system_user_s3_upload_writeonly" {
     effect = "Allow"
 
     resources = [
-      "${var.upload_bucket_arn}/${var.org_name}/${var.system_name}/*",
+      "${var.upload_bucket_arn}/*",
+      "${var.upload_bucket_arn}/${var.org_name}/${var.system_name}/"
     ]
   }
 }

--- a/infra/terraform/modules/data_upload_user/iam.tf
+++ b/infra/terraform/modules/data_upload_user/iam.tf
@@ -18,7 +18,7 @@ data "aws_iam_policy_document" "system_user_s3_upload_writeonly" {
 
     resources = [
       "${var.upload_bucket_arn}/*",
-      "${var.upload_bucket_arn}/${var.org_name}/${var.system_name}/"
+      "${var.upload_bucket_arn}/${var.org_name}/${var.system_name}/",
     ]
   }
 }


### PR DESCRIPTION
update the /modules/data_upload_user/iam.tf file so that the writeonly account can push files to mojap-land bucket. 