### PR TITLE
Idled Ingress Class fixer

### DIFF
--- a/scripts/fix_idled_ingress_class.sh
+++ b/scripts/fix_idled_ingress_class.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -e
+###
+# Find any deployments that are idled and set their ingress to 'disabled'
+###
+
+while read obj ns
+do
+    if [[ "$ns" == *"user-"* ]]; then
+        echo $ns $obj
+        read class <<< $(kubectl get ing -n $ns $obj -o=jsonpath='{.metadata.annotations.kubernetes\.io/ingress\.class}')
+        if [[ "$class" == "nginx" ]]; then
+            echo "patching ingress class from $class to 'disabled'"
+            echo "  kubectl patch ing $obj -n $ns -p '{"metadata": {"annotations": {"kubernetes.io/ingress.class":"disabled"} } }'"
+            kubectl patch ing $obj -n $ns -p '{"metadata": {"annotations": {"kubernetes.io/ingress.class":"disabled"} } }'
+        else
+            echo " ⛔ Skipping: $ns/$obj because they already have class $class"
+        fi
+    fi
+done <<< $(kubectl get deployments --all-namespaces -o=jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.metadata.namespace}{"\t"}{.metadata.labels.mojanalytics\.xyz/idled}{"\n"}{end}' | grep true | cut -f1,2)


### PR DESCRIPTION
this script fixes ingresses in a bad state for idled rstudio instances.
If the ingress object for the user is still enabled but they are idled then they
can never be un-idled because the request will try to reach their pod instead of
the unidler.
This script loops through all idled deployments and then gets the corresponding
ingress object, the object is then checked for having an nginx ingress class
annotation. If it has this annotation then it is changed to 'disabled'
