### PR TITLE
Improved instructions for lambda go compilation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,8 @@
 __pycache__
 .cache
 venv
+
+/infra/terraform/global/assets/create_etcd_ebs_snapshot/create_etcd_ebs_snapshot
+/infra/terraform/global/assets/create_etcd_ebs_snapshot/create_etcd_ebs_snapshot.zip
+/infra/terraform/global/assets/prune_ebs_snapshots/prune_ebs_snapshots
+/infra/terraform/global/assets/prune_ebs_snapshots/prune_ebs_snapshots.zip

--- a/README.md
+++ b/README.md
@@ -48,6 +48,15 @@ All [Kubernetes][kubernetes] resources are managed as [Helm][helm] charts, the K
 
 Global AWS resources (DNS and S3 buckets) are resources which are shared or referred to by all instances of the platform, and only need to be created once. These resources have likely already been created, in which case you can skip ahead to remote state setup, but if you are starting from a clean slate:
 
+### Compiling Go functions
+
+You need to compile some Go scripts (because AWS Lambda requires binaries). Follow the build instructions found in these READMEs:
+
+* [Create etcd EBS Snapshot README](infra/terraform/global/assets/create_etcd_ebs_snapshot/README.md)
+* [Prune EBS Snapshot README](infra/terraform/global/assets/prune_ebs_snapshots/README.md)
+
+If you miss this step, you'll get an error to do with `archive_file.create_etcd_ebs_snapshot`/`archive_file.prune_ebs_snapshots` not finding a file (the compiled one).
+
 ```
 # Enter global Terraform resources directory
 cd infra/terraform/global
@@ -55,11 +64,11 @@ cd infra/terraform/global
 # set up remote state backend and pull modules
 terraform init
 
-# check that Terraform plans to create two S3 buckets (Terraform and Kops state) and a root DNS zone in Route53
-terraform plan
+# check that Terraform plans to create global infra (e.g. the Kops S3 bucket and a root DNS zone in Route53)
+terraform plan -var-file="assets/create_etcd_ebs_snapshot/create_etcd_ebs_snapshots.tfvars" -var-file="assets/prune_ebs_snapshots/vars_prune_ebs_snapshots.tfvars"
 
 # create resources
-terraform apply
+terraform apply -var-file="assets/create_etcd_ebs_snapshot/create_etcd_ebs_snapshots.tfvars" -var-file="assets/prune_ebs_snapshots/vars_prune_ebs_snapshots.tfvars"
 ```
 
 ### NFS server licensing

--- a/infra/terraform/global/assets/create_etcd_ebs_snapshot/README.md
+++ b/infra/terraform/global/assets/create_etcd_ebs_snapshot/README.md
@@ -8,23 +8,36 @@ You'll need a working [Go](www.golang.org/doc/) environment to build a distribut
 
 For working with the [Go](www.golang.org) runtime in AWS Lambda. See [lambda-go-how-to-create-deployment-package](https://docs.aws.amazon.com/lambda/latest/dg/lambda-go-how-to-create-deployment-package.html)
 
-To Build and Deploy
----------
+To Build
+--------
 
 The Lambda execution environment uses a Linux kernel, so you'll need to build the binary for linux
-```
-GOOS=linux go build main.go 
 
+A good way to do this if you don't have Go installed is to use Docker:
+```
+cd infra/terraform/global/assets/create_etcd_ebs_snapshot/
+docker run -it -v "$(pwd)":/src golang:alpine sh
+```
+This will start a Docker container with Go installed and launch a shell. From
+there you need to install git and the aws client library:
+```
+cd /src
+apk add git
+go get github.com/aws/aws-sdk-go
+```
+Then you can compile the binary using the following command:
+```
+GOOS=linux go build -o create_etcd_ebs_snapshot main.go
 ```
 
-Once you have built a distribution with the command above. Rename the distribution to the same name as `function_name` from your [terraform](https://www.terraform.io/) lambda resource 
-and deploy the lambda function with the [terraform](https://www.terraform.io/) commands below
+To Deploy
+---------
+
+Once you have built a binary/distribution with the command above, deploy the lambda function with the [terraform](https://www.terraform.io/) commands below
 
 __Note__ the commands below assume you are at the __root__ of the repository
 
 ```
-mv infra/terraform/global/assets/create_etcd_ebs_snapshots/main infra/terraform/global/assets/create_etcd_ebs_snapshots/create_etcd_ebs_snapshots
-
 terraform plan -target=module.kubernetes_create_etcd_ebs_snapshots -var-file=infra/terraform/global/assets/create_etcd_ebs_snapshots/vars_create_etcd_ebs_snapshots.tfvars
 
 terraform apply -target=module.kubernetes_create_etcd_ebs_snapshots -var-file=infra/terraform/global/assets/create_etcd_ebs_snapshots/vars_create_etcd_ebs_snapshots.tfvars

--- a/infra/terraform/global/assets/prune_ebs_snapshots/README.md
+++ b/infra/terraform/global/assets/prune_ebs_snapshots/README.md
@@ -7,16 +7,32 @@ You'll also need a working [Go](www.golang.org/doc/) environment to build a dist
 
 For working with the [Go](www.golang.org) runtime in AWS Lambda. See [lambda-go-how-to-create-deployment-package](https://docs.aws.amazon.com/lambda/latest/dg/lambda-go-how-to-create-deployment-package.html)
 
-To Build and Deploy
----------
+To Build
+--------
 
 The Lambda execution environment uses a Linux kernel, so you'll need to build the binary for linux
-```
-GOOS=linux go build prune_ebs_snapshots.go 
 
+A good way to do this if you don't have Go installed is to use Docker:
+```
+cd infra/terraform/global/assets/prune_ebs_snapshots
+docker run -it -v "$(pwd)":/src golang:alpine sh
+```
+This will start a Docker container with Go installed and launch a shell. From
+there you need to install git and the aws client library:
+```
+cd /src
+apk add git
+go get github.com/aws/aws-sdk-go
+```
+Then you can compile the binary using the following command:
+```
+GOOS=linux go build prune_ebs_snapshots.go
 ```
 
-Once you have built a distribution with the command above. Deploy the lambda function with the [terraform](https://www.terraform.io/) commands below
+To Deploy
+---------
+
+Once you have built a binary/distribution with the command above, deploy the lambda function with the [terraform](https://www.terraform.io/) commands below
 
 __Note__ the commands below assume you are at the __root__ of the repository
 


### PR DESCRIPTION
## What

Use a docker container to compile the go code.

Without doing these steps you get errors like this when running the global terraform:
```
$ terraform plan
Error: Error refreshing state: 2 error(s) occurred:

* data.archive_file.kubernetes_prune_ebs_snapshots_code: 1 error(s) occurred:

* data.archive_file.kubernetes_prune_ebs_snapshots_code: data.archive_file.kubernetes_prune_ebs_snapshots_code: error archiving file: could not archive missing file: assets/prune_ebs_snapshots/prune_ebs_snapshots
* data.archive_file.kubernetes_etcd_ebs_snapshot_code: 1 error(s) occurred:

* data.archive_file.kubernetes_etcd_ebs_snapshot_code: data.archive_file.kubernetes_etcd_ebs_snapshot_code: error archiving file: could not archive missing file: assets/create_etcd_ebs_snapshot/create_etcd_ebs_snapshot
```

## How to review

Follow the instructions. Run terraform to see that you don't get errors about missing archive any more.