### PR TITLE
Remove s3 expiration setting (that AWS doesnt allow)

### DIFF
--- a/infra/terraform/modules/data_backup/s3.tf
+++ b/infra/terraform/modules/data_backup/s3.tf
@@ -34,7 +34,7 @@ resource "aws_s3_bucket" "nfs_backup" {
     }
 
     expiration {
-      days                         = 90
+      days = 90
     }
 
     noncurrent_version_transition {

--- a/infra/terraform/modules/data_backup/s3.tf
+++ b/infra/terraform/modules/data_backup/s3.tf
@@ -35,7 +35,6 @@ resource "aws_s3_bucket" "nfs_backup" {
 
     expiration {
       days                         = 90
-      expired_object_delete_marker = true
     }
 
     noncurrent_version_transition {


### PR DESCRIPTION
expired_object_delete_marker isn't allowed to be true when expiration is enabled. AWS resists this setting and therefore the rule fires every time you run `terraform plan`, which is annoying & confusing.

```
  ~ module.data_backup.aws_s3_bucket.nfs_backup
      lifecycle_rule.0.expiration.3731869058.date:                                                           "" => ""
      lifecycle_rule.0.expiration.3731869058.days:                                                           "" => "90"
      lifecycle_rule.0.expiration.3731869058.expired_object_delete_marker:                                   "" => "true"
      lifecycle_rule.0.expiration.4042355233.date:                                                           "" => ""
      lifecycle_rule.0.expiration.4042355233.days:                                                           "90" => "0"
      lifecycle_rule.0.expiration.4042355233.expired_object_delete_marker:                                   "false" => "false"
```

Fuller explanation, see: https://github.com/hashicorp/terraform/issues/9119
