### PR TITLE
Mark 4 buckets as SSE encrypted, as they are on dev & alpha

### DIFF
--- a/infra/terraform/modules/data_backup/s3.tf
+++ b/infra/terraform/modules/data_backup/s3.tf
@@ -47,4 +47,11 @@ resource "aws_s3_bucket" "nfs_backup" {
       days = 30
     }
   }
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
 }

--- a/infra/terraform/modules/data_buckets/crest.tf
+++ b/infra/terraform/modules/data_buckets/crest.tf
@@ -10,6 +10,14 @@ resource "aws_s3_bucket" "crest" {
   tags {
     Name = "${var.env}-moj-analytics-crest"
   }
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
 }
 
 # IAM Group

--- a/infra/terraform/modules/data_buckets/s3.tf
+++ b/infra/terraform/modules/data_buckets/s3.tf
@@ -5,6 +5,14 @@ resource "aws_s3_bucket" "source" {
   tags {
     Name = "${var.env}-moj-analytics-source"
   }
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
 }
 
 resource "aws_s3_bucket" "scratch" {
@@ -13,6 +21,14 @@ resource "aws_s3_bucket" "scratch" {
 
   tags {
     Name = "${var.env}-moj-analytics-scratch"
+  }
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
   }
 }
 


### PR DESCRIPTION
I don't know why these buckets aren't SSE in the terraform (the others are). And I don't know how they stayed encrypted on S3. Anyway, this PR stops terraform plan saying this:
```
cd infra/terraform/platform
terraform plan -var-file=vars/$ENVNAME.tfvars
...
  ~ module.data_backup.aws_s3_bucket.nfs_backup
      server_side_encryption_configuration.#:                                                                "1" => "0"
      server_side_encryption_configuration.0.rule.#:                                                         "1" => "0"
      server_side_encryption_configuration.0.rule.0.apply_server_side_encryption_by_default.#:               "1" => "0"
      server_side_encryption_configuration.0.rule.0.apply_server_side_encryption_by_default.0.sse_algorithm: "AES256" => ""

  ~ module.data_buckets.aws_s3_bucket.crest
      server_side_encryption_configuration.#:                                                                "1" => "0"
      server_side_encryption_configuration.0.rule.#:                                                         "1" => "0"
      server_side_encryption_configuration.0.rule.0.apply_server_side_encryption_by_default.#:               "1" => "0"
      server_side_encryption_configuration.0.rule.0.apply_server_side_encryption_by_default.0.sse_algorithm: "AES256" => ""

  ~ module.data_buckets.aws_s3_bucket.scratch
      server_side_encryption_configuration.#:                                                                "1" => "0"
      server_side_encryption_configuration.0.rule.#:                                                         "1" => "0"
      server_side_encryption_configuration.0.rule.0.apply_server_side_encryption_by_default.#:               "1" => "0"
      server_side_encryption_configuration.0.rule.0.apply_server_side_encryption_by_default.0.sse_algorithm: "AES256" => ""

  ~ module.data_buckets.aws_s3_bucket.source
      server_side_encryption_configuration.#:                                                                "1" => "0"
      server_side_encryption_configuration.0.rule.#:                                                         "1" => "0"
      server_side_encryption_configuration.0.rule.0.apply_server_side_encryption_by_default.#:               "1" => "0"
      server_side_encryption_configuration.0.rule.0.apply_server_side_encryption_by_default.0.sse_algorithm: "AES256" => ""
``` 