### PR TITLE
Terraform docs improved

### DIFF
--- a/README.md
+++ b/README.md
@@ -509,3 +509,9 @@ The two instances can then be accessed on `https://localhost:8443/` and `https:/
 7. Login to the admin UI of `softnas-1` and check the `SnapReplicate` section to confirm that HA setup was successful
 
 The SoftNAS secondary will monitor availability of the primary, and take over primary status if it cannot ping the current primary. Takeover is performed by updating the AWS routing tables to point the VirtualIP address to the current secondary. Refer to the [SoftNAS HA admin guide](https://www.softnas.com/docs/softnas/v3/snapha-html/ha_operations.html) for more info on how to manage replacement of failed instances, and other HA operations.
+
+## What's next
+
+Now you have the infrastructure set-up, next install the charts: https://github.com/ministryofjustice/analytics-platform-helm-charts/blob/master/charts/README.md
+
+Ensure you refer to the READMEs for each chart, for additional setup e.g. [Auth0 setup for cpanel](https://github.com/ministryofjustice/analytics-platform-helm-charts/blob/master/charts/cpanel/README.md)

--- a/README.md
+++ b/README.md
@@ -512,6 +512,7 @@ The SoftNAS secondary will monitor availability of the primary, and take over pr
 
 ## What's next
 
-Now you have the infrastructure set-up, next install the charts: https://github.com/ministryofjustice/analytics-platform-helm-charts/blob/master/charts/README.md
+Now you have the infrastructure set-up, next install the charts: https://github.com/ministryofjustice/analytics-platform-helm-charts/blob/master/README.md
+
 
 Ensure you refer to the READMEs for each chart, for additional setup e.g. [Auth0 setup for cpanel](https://github.com/ministryofjustice/analytics-platform-helm-charts/blob/master/charts/cpanel/README.md)


### PR DESCRIPTION
* "Working with an existing environment" section felt redundant since you have to do 'terraform init' and once you add all the info about that you have duplicated most of the info in the preceding section. So I've combined the section.
* Difficulty switching backends was a trap I fell into several times, so I've explained about that. If there is a better way than deleting the .terraform dir then I'd love to know it. Adding `-backend=true` didn't do it.
* "You can usually ignore these actions" lists account for less-than-ideal terraform things, which fire every time. If we can fix these up then we can delete them from the list. Listing them means one less thing for the user to worry about, when they are editing things in other areas and run terraform.
* `ses_ap_email_identity_arn` param was missed off - a recent addition.
