### PR TITLE
Script: add helper script to put `idleable` annotation on deployed tools

### DIFF
--- a/scripts/label_jupyter_and_rstudio_deployments.sh
+++ b/scripts/label_jupyter_and_rstudio_deployments.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -ex
+
+IDLEABLE_LABEL=${1:-"mojanalytics.xyz/idleable"}
+
+for user in $(kubectl get ns | grep user- | cut -f 1 -d ' ' | sed 's/^user-//'); do
+    namespace=user-$user
+
+    kubectl label deployments -l app=rstudio ${IDLEABLE_LABEL}=true -n $namespace
+    kubectl label deployments -l app=jupyter-lab ${IDLEABLE_LABEL}=true -n $namespace
+
+done


### PR DESCRIPTION
This script will add the idleable annotation to any existing rstudio or
jupyter-lab deployments.

Just putting here for reference but really it'll only be run once

## How to review
I've already run this on dev but... delete the annotation from a deployment and run this again, it will add the annotation back.
