### PR TITLE
Remove unused filtering to find the softnas ami

### DIFF
--- a/infra/terraform/modules/user_nfs_softnas/ec2.tf
+++ b/infra/terraform/modules/user_nfs_softnas/ec2.tf
@@ -1,30 +1,3 @@
-data "aws_ami" "softnas" {
-  most_recent = true
-
-  filter {
-    name   = "name"
-    values = ["SoftNAS Cloud Meter*"]
-  }
-
-  filter {
-    name   = "virtualization-type"
-    values = ["hvm"]
-  }
-
-  filter {
-    name   = "architecture"
-    values = ["x86_64"]
-  }
-
-  filter {
-    name   = "owner-alias"
-    values = ["aws-marketplace"]
-  }
-
-  # SoftNAS account ID
-  owners = ["679593333241"]
-}
-
 resource "aws_key_pair" "softnas" {
   key_name   = "${var.env}-softnas"
   public_key = "${var.ssh_public_key}"


### PR DESCRIPTION
The AMI is specified explicitly now, rather than using this 'filtering'. The only reference to this code (`data.aws_ami.softnas`) was removed in commit https://github.com/ministryofjustice/analytics-platform-ops/commit/08cf30206797c0c36eac37a28ee4ce023aa586c3