### PR TITLE
Mention that Auth0 GitHub Integration also deploys hosted pages too

### DIFF
--- a/README.md
+++ b/README.md
@@ -491,12 +491,12 @@ In Auth0 you need to create some Applications.
 
 The Client ID and Client Secret values will be used in various helm chart configurations.
 
-### Auth0 Rules
+### Auth0 Rules & Hosted Pages
 
-Auth0 needs 'rules' installed, to ensure only certain people can log-in, for example.
+Auth0 needs 'rules' installed, to ensure only certain people can log-in, for example. We also use the 'Hosted pages' feature to customize the login page. Both are continuously deployed with the same setup, as follows.
 
 Find the rules in this repo: https://github.com/ministryofjustice/analytics-platform-auth0
-in the dev or alpha branches. Create a new branch based on these and adapt the following settings in them:
+in the dev or alpha branches. Create a new branch (or fork it if another organization) and adapt the following settings in them:
 
 | Setting | Description |
 | ------- | ----------- |


### PR DESCRIPTION
Auto-deploy of these pages is documented here: https://auth0.com/docs/extensions/github-deploy#deploy-hosted-pages

I separately added the hosted page source to the analytics-platform-auth0 repo (sorry, I should have done PRs for those):

https://github.com/ministryofjustice/analytics-platform-auth0/tree/alpha/pages
https://github.com/ministryofjustice/analytics-platform-auth0/tree/dev/pages

They deployed fine (dev and alpha):
![screen shot 2018-10-23 at 12 20 50](https://user-images.githubusercontent.com/307612/47357421-2cdef000-d6b6-11e8-9778-7390da9f93a3.png)

and the result is the same:
![screen shot 2018-10-23 at 12 21 13](https://user-images.githubusercontent.com/307612/47357470-4b44eb80-d6b6-11e8-9de3-08f75fa676c5.png)

