### PR TITLE
Certifi package with that date no longer exists. 

### DIFF
--- a/infra/terraform/modules/aws_account_logging/cloudtrail/requirements.txt
+++ b/infra/terraform/modules/aws_account_logging/cloudtrail/requirements.txt
@@ -1,2 +1,2 @@
-certifi==2016.8.8
+certifi
 elasticsearch>=5.0.0,<6.0.0


### PR DESCRIPTION
## What

The certifi package specified no longer exists.

certifi is designed so that you always use the latest, so remove the pinning.

## How to review

Rerun terraform global for a fresh platform.