### PR TITLE
Fix "prefix" error with terraform/pip/osx/brew

### DIFF
--- a/infra/terraform/modules/aws_account_logging/cloudtrail/setup.cfg
+++ b/infra/terraform/modules/aws_account_logging/cloudtrail/setup.cfg
@@ -1,0 +1,2 @@
+[install]
+prefix=

--- a/infra/terraform/modules/aws_account_logging/s3logs/setup.cfg
+++ b/infra/terraform/modules/aws_account_logging/s3logs/setup.cfg
@@ -1,0 +1,2 @@
+[install]
+prefix=


### PR DESCRIPTION
## Issue

When running 'terraform apply' (for global), if you have macOS and used Homebrew to install python, then you get this pip install error:

     must supply either home or prefix/exec-prefix -- not both

It's discussed here: https://stackoverflow.com/q/24257803

## What

We add setup.cfg file that sets the prefix to nothing and it works around the bug.

## How to test

Run:

    terraform apply -var-file="assets/create_etcd_ebs_snapshot/create_etcd_ebs_snapshots.tfvars" -var-file="assets/prune_ebs_snapshots/vars_prune_ebs_snapshots.tfvars" -target=module.aws_account_logging.null_resource.cloudtrail_install_deps -target=module.aws_account_logging.null_resource.s3logs_install_deps

Title the PR to complete the sentence: "Merging this PR will ..."
