### PR TITLE
adds Auth0 costs note

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,8 @@ You can now quit the launch process because terraform will do the launch. The im
     3. In the drop-down menu click "Create tenant"
          * Tenant domain: include the environment name, if not the platform
 
+    NB It's recommended for admins to use Multifactor Authentication (MFA) when accessing the Auth web console, which requires a ["Developer Pro" plan](https://auth0.com/pricing). Currently this costs from $14/month, which works with up to 100 External users (i.e. people using the platform).
+
 2. Create an application:
 
     1. In the side-bar click "Applications"


### PR DESCRIPTION
This seems useful info for someone setting this up for a trial or a real install.

From tests with accelerator platform, it seems the Free plan allows External users to use MFA. It's just when admins want to use MFA for logging into the console when it needs a paid plan.
