### PR TITLE
Fix terraform softnas_num_instances variable

### DIFF
--- a/infra/terraform/platform/main.tf
+++ b/infra/terraform/platform/main.tf
@@ -38,7 +38,7 @@ module "data_buckets" {
 module "user_nfs_softnas" {
   source = "../modules/user_nfs_softnas"
 
-  num_instances             = 1
+  num_instances             = "${var.softnas_num_instances}"
   softnas_ami_id            = "${var.softnas_ami_id}"
   instance_type             = "${var.softnas_instance_type}"
   default_volume_size       = "${var.softnas_volume_size}"


### PR DESCRIPTION
The use of the `softnas_num_instances` variable was missed as part of the move to workspaces, so both alpha and dev ended up with a single instance configured, but alpha should have two instances. Both alpha and dev `.tfvars` file have the correct number of instances specified, so correct values will be used in both environments.
