### PR TITLE
Support >1 use of the SoftNAS terraform module

### DIFF
--- a/infra/terraform/modules/user_nfs_softnas/dns.tf
+++ b/infra/terraform/modules/user_nfs_softnas/dns.tf
@@ -1,6 +1,6 @@
 resource "aws_route53_record" "softnas" {
   zone_id = "${var.dns_zone_id}"
-  name    = "softnas-${count.index}.${var.dns_zone_domain}"
+  name    = "${var.name_identifier}-${count.index}.${var.dns_zone_domain}"
   type    = "A"
   ttl     = "30"
   records = ["${element(aws_instance.softnas.*.private_ip, count.index)}"]

--- a/infra/terraform/modules/user_nfs_softnas/dns.tf
+++ b/infra/terraform/modules/user_nfs_softnas/dns.tf
@@ -10,7 +10,7 @@ resource "aws_route53_record" "softnas" {
 
 resource "aws_route53_record" "nfs_mountpoint" {
   zone_id = "${var.dns_zone_id}"
-  name    = "nfs.${var.dns_zone_domain}"
+  name    = "${var.nfs_dns_prefix}.${var.dns_zone_domain}"
   type    = "A"
   ttl     = "30"
 

--- a/infra/terraform/modules/user_nfs_softnas/ebs.tf
+++ b/infra/terraform/modules/user_nfs_softnas/ebs.tf
@@ -14,7 +14,7 @@ resource "aws_ebs_volume" "softnas_vol1" {
   count = "${var.num_instances}"
 
   tags {
-    Name = "${var.env}-softnas-vol1"
+    Name = "${var.env}-${var.name_identifier}-vol1"
   }
 }
 

--- a/infra/terraform/modules/user_nfs_softnas/ec2.tf
+++ b/infra/terraform/modules/user_nfs_softnas/ec2.tf
@@ -1,10 +1,10 @@
 resource "aws_key_pair" "softnas" {
-  key_name   = "${var.env}-softnas"
+  key_name   = "${var.env}-${var.name_identifier}"
   public_key = "${var.ssh_public_key}"
 }
 
 resource "aws_security_group" "softnas" {
-  name        = "${var.env}-softnas"
+  name        = "${var.env}-${var.name_identifier}"
   description = "Allow NFS from cluster and HTTP from SSH bastions"
   vpc_id      = "${var.vpc_id}"
 
@@ -69,7 +69,7 @@ resource "aws_network_interface" "softnas_eth0" {
   count = "${var.num_instances}"
 
   tags {
-    Name = "${var.env}-softnas-${count.index}-eth0"
+    Name = "${var.env}-${var.name_identifier}-${count.index}-eth0"
   }
 }
 
@@ -83,7 +83,7 @@ resource "aws_network_interface" "softnas_eth1" {
   count = "${var.num_instances}"
 
   tags {
-    Name = "${var.env}-softnas-${count.index}-eth1"
+    Name = "${var.env}-${var.name_identifier}-${count.index}-eth1"
   }
 }
 
@@ -106,6 +106,6 @@ resource "aws_instance" "softnas" {
   }
 
   tags {
-    Name = "${var.env}-softnas-${count.index}"
+    Name = "${var.env}-${var.name_identifier}-${count.index}"
   }
 }

--- a/infra/terraform/modules/user_nfs_softnas/iam.tf
+++ b/infra/terraform/modules/user_nfs_softnas/iam.tf
@@ -1,5 +1,5 @@
 resource "aws_iam_instance_profile" "softnas" {
-  name = "${var.env}-softnas"
+  name = "${var.env}-${var.name_identifier}"
   role = "${var.softnas_role_name}"
 
   # workaround for AWS reporting that the instance profile has been created

--- a/infra/terraform/modules/user_nfs_softnas/inputs.tf
+++ b/infra/terraform/modules/user_nfs_softnas/inputs.tf
@@ -6,6 +6,10 @@ variable "node_security_group_id" {}
 variable "bastion_security_group_id" {}
 variable "ssh_public_key" {}
 
+variable "name_identifier" {
+  default = "softnas"
+  description = "Will be interpolated into resource names, e.g. EBS volume 'softnas' -> 'dev-softnas-vol1'"
+}
 variable "subnet_ids" {
   type = "list"
 }

--- a/infra/terraform/modules/user_nfs_softnas/inputs.tf
+++ b/infra/terraform/modules/user_nfs_softnas/inputs.tf
@@ -7,9 +7,15 @@ variable "bastion_security_group_id" {}
 variable "ssh_public_key" {}
 
 variable "name_identifier" {
-  default = "softnas"
+  default     = "softnas"
   description = "Will be interpolated into resource names, e.g. EBS volume 'softnas' -> 'dev-softnas-vol1'"
 }
+
+variable "nfs_dns_prefix" {
+  default     = "nfs"
+  description = "First part of NFS DNS record, e.g. 'nfs' -> 'nfs.dev.mojanalytics.xyz'"
+}
+
 variable "subnet_ids" {
   type = "list"
 }


### PR DESCRIPTION
The SoftNAS terraform module assumes that only one instance would be used, but there will be two during data migration to a new SoftNAS instance, so additional variables have been added to avoid duplication of AWS resource names and DNS collisions.