### PR TITLE
Add missing SoftNAS EBS volumes to Terraform

### DIFF
--- a/infra/terraform/modules/user_nfs_softnas/ebs.tf
+++ b/infra/terraform/modules/user_nfs_softnas/ebs.tf
@@ -1,3 +1,10 @@
+### IMPORTANT NOTE
+# The following volume definitions include volumes that were provisioned outside 
+# of Terraform via the SoftNAS GUI. Sizes differ (2.x250GB, 2x500GB), and two
+# volumes have encryption enabled, and two don't. This is not ideal, but as
+# SoftNAS is likely to be replaced with an alternative product the as-is
+# infrastructure config has been captured here for now.
+
 ###
 # See http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/device_naming.html for
 # device naming rules
@@ -14,13 +21,75 @@ resource "aws_ebs_volume" "softnas_vol1" {
   count = "${var.num_instances}"
 
   tags {
-    Name = "${var.env}-${var.name_identifier}-vol1"
+    Name = "${var.env}-${var.name_identifier}-${count.index}-vol1"
+  }
+}
+
+resource "aws_ebs_volume" "softnas_vol2" {
+  availability_zone = "${element(aws_instance.softnas.*.availability_zone, count.index)}"
+  type              = "gp2"
+  size              = "${var.default_volume_size}"
+  encrypted         = true
+
+  count = "${var.num_instances}"
+
+  tags {
+    Name = "${var.env}-${var.name_identifier}-${count.index}-vol2"
+  }
+}
+
+resource "aws_ebs_volume" "softnas_vol3" {
+  availability_zone = "${element(aws_instance.softnas.*.availability_zone, count.index)}"
+  type              = "gp2"
+  size              = "500"
+
+  count = "${var.num_instances}"
+
+  tags {
+    Name = "${var.env}-${var.name_identifier}-${count.index}-vol3"
+  }
+}
+
+resource "aws_ebs_volume" "softnas_vol4" {
+  availability_zone = "${element(aws_instance.softnas.*.availability_zone, count.index)}"
+  type              = "gp2"
+  size              = "500"
+  encrypted         = true
+
+  count = "${var.num_instances}"
+
+  tags {
+    Name = "${var.env}-${var.name_identifier}-${count.index}-vol4"
   }
 }
 
 resource "aws_volume_attachment" "softnas_vol1" {
   device_name = "/dev/sdf"
   volume_id   = "${element(aws_ebs_volume.softnas_vol1.*.id, count.index)}"
+  instance_id = "${element(aws_instance.softnas.*.id, count.index)}"
+
+  count = "${var.num_instances}"
+}
+
+resource "aws_volume_attachment" "softnas_vol2" {
+  device_name = "/dev/sdg"
+  volume_id   = "${element(aws_ebs_volume.softnas_vol2.*.id, count.index)}"
+  instance_id = "${element(aws_instance.softnas.*.id, count.index)}"
+
+  count = "${var.num_instances}"
+}
+
+resource "aws_volume_attachment" "softnas_vol3" {
+  device_name = "/dev/sdh"
+  volume_id   = "${element(aws_ebs_volume.softnas_vol3.*.id, count.index)}"
+  instance_id = "${element(aws_instance.softnas.*.id, count.index)}"
+
+  count = "${var.num_instances}"
+}
+
+resource "aws_volume_attachment" "softnas_vol4" {
+  device_name = "/dev/sdi"
+  volume_id   = "${element(aws_ebs_volume.softnas_vol4.*.id, count.index)}"
   instance_id = "${element(aws_instance.softnas.*.id, count.index)}"
 
   count = "${var.num_instances}"


### PR DESCRIPTION
Additional EBS volumes had been added via the SoftNAS GUI and were not represented in Terraform; this commit adds them.

EBS volume tags have also been modified to indicate which of the SoftNAS HA pair a given volume is attached to, e.g. `alpha-softnas-0-vol1` and `alpha-softnas-1-vol1` rather than 2x `alpha-softnas-vol1`.