### PR TITLE
Remove deprecated `current` arg from `aws_region` data source

### DIFF
--- a/infra/terraform/modules/data_backup/data.tf
+++ b/infra/terraform/modules/data_backup/data.tf
@@ -1,3 +1,1 @@
-data "aws_region" "current" {
-  current = true
-}
+data "aws_region" "current" {}


### PR DESCRIPTION
The `current` argument to the `aws_region` data provider is now deprecated, as it defaults to the current configured region when no region name or endpoint is defined.