### PR TITLE
Rename AWS SAML provider to $ENV-auth0

### DIFF
--- a/infra/terraform/modules/federated_identity/iam.tf
+++ b/infra/terraform/modules/federated_identity/iam.tf
@@ -10,7 +10,7 @@ data "template_file" "saml_metadata" {
 }
 
 resource "aws_iam_saml_provider" "idp" {
-  name                   = "${var.env}-idp"
+  name                   = "${var.env}-auth0"
   saml_metadata_document = "${data.template_file.saml_metadata.rendered}"
 }
 


### PR DESCRIPTION
AWS SAML provider suffixes had been changed from ‘auth0’ to the more generic ‘idp’, but references in auth0 rules and user IAM role trust policies had not been updated to match. This commit reverts that change for now.