### PR TITLE
Cloutrail logs

### DIFF
--- a/infra/elasticsearch/templates/cloudtrail.json
+++ b/infra/elasticsearch/templates/cloudtrail.json
@@ -4,11 +4,7 @@
     "index.refresh_interval": "5s"
   },
   "mappings": {
-    "_default_": {
-      "_all": {
-        "enabled": false,
-        "omit_norms": true
-      },
+    "cloudtrail-log": {
       "dynamic_templates": [
         {
           "date_fields": {
@@ -25,7 +21,7 @@
             "match": "*",
             "match_mapping_type": "object",
             "mapping": {
-              "type": "geo_point",
+              "type": "object",
               "doc_values": true
             }
           }
@@ -40,7 +36,6 @@
           "type": "text"
         },
         "geoip": {
-          "type": "object",
           "dynamic": true,
           "properties": {
             "ip": {

--- a/infra/terraform/modules/aws_account_logging/cloudtrail/requirements.txt
+++ b/infra/terraform/modules/aws_account_logging/cloudtrail/requirements.txt
@@ -1,2 +1,2 @@
 certifi
-elasticsearch>=5.0.0,<6.0.0
+elasticsearch>=6.0.0,<7.0.0


### PR DESCRIPTION
__Update Elasticsearch Client__

- We now use Elasticsearch version 6.x

__Update Template__

- Removing deprecated `_all` block
- Template mappings and data can only have one type in ES 6 so removing `_default_` (which will be deprecated)
- Removed superfluous `object` type definition
- Modified conflicting `geo_point` mapping type to `object`
