### PR TITLE
Kubelet Auth

### DIFF
--- a/infra/terraform/modules/kops_spec/templates/kops.yaml.tmpl
+++ b/infra/terraform/modules/kops_spec/templates/kops.yaml.tmpl
@@ -51,6 +51,11 @@ ${etcd_events_members}
     oidcUsernameClaim: nickname
     runtimeConfig:
       batch/v2alpha1: "true"
+  kubelet:
+    anonymousAuth: false
+    authenticationTokenWebhook: true
+    authorizationMode: Webhook
+    readOnlyPort: 0
   kubernetesApiAccess:
   - 0.0.0.0/0
   kubernetesVersion: ${k8s_version}


### PR DESCRIPTION
[Trello](https://trello.com/c/YNDTzEIx)

This is to mitigate the [vulnerability](https://medium.com/handy-tech/analysis-of-a-kubernetes-hack-backdooring-through-kubelet-823be5c3d67c) described.

- Disabling anonymous auth and enabling serviceaccount token authentication.
- Disabling Read-Only metrics port

