### PR TITLE
Enable Terraform state locking for `global` and create dynamoDB tables for `platform` and `platform-base`

### DIFF
--- a/infra/terraform/global/dynamodb.tf
+++ b/infra/terraform/global/dynamodb.tf
@@ -1,0 +1,31 @@
+resource "aws_dynamodb_table" "terraform-lock-platform-base" {
+  name           = "terraform-platform-base"
+  hash_key       = "LockID"
+  read_capacity  = 5
+  write_capacity = 5
+
+  server_side_encryption {
+    enabled = true
+  }
+
+  attribute {
+    name = "LockID"
+    type = "S"
+  }
+}
+
+resource "aws_dynamodb_table" "terraform-lock-platform" {
+  name           = "terraform-platform"
+  hash_key       = "LockID"
+  read_capacity  = 5
+  write_capacity = 5
+
+  server_side_encryption {
+    enabled = true
+  }
+
+  attribute {
+    name = "LockID"
+    type = "S"
+  }
+}

--- a/infra/terraform/global/main.tf
+++ b/infra/terraform/global/main.tf
@@ -1,8 +1,9 @@
 terraform {
   backend "s3" {
-    bucket = "terraform.analytics.justice.gov.uk"
-    key    = "base/terraform.tfstate"
-    region = "eu-west-1"
+    bucket         = "terraform.analytics.justice.gov.uk"
+    key            = "base/terraform.tfstate"
+    region         = "eu-west-1"
+    dynamodb_table = "terraform-global"
   }
 }
 


### PR DESCRIPTION
Enables [state locking with DynamoDB](https://www.terraform.io/docs/backends/state.html) for `global` resources, and creates DynamoDB tables for state locking in `platform-base` and `platform` resources. State locking will be enabled for `platform` and `platform-base` once the [auth0 provider PR](https://github.com/ministryofjustice/analytics-platform-ops/pull/244) has been merged, as an in-progress `apply` of auth0 provider-managed resources currently means that an `apply` in all branches causes an error due to the missing auth0 plugin. In short, it's better to wait for the auth0 provider changes to be merged before proceeding.