### PR TITLE
Scale Highmem to 0

### DIFF
--- a/infra/terraform/modules/ec2_cluster_autoscaler_policy/data.tf
+++ b/infra/terraform/modules/ec2_cluster_autoscaler_policy/data.tf
@@ -1,4 +1,4 @@
-data "aws_autoscaling_groups" "nodes" {
+data "aws_autoscaling_groups" "asgs" {
   filter {
     name   = "key"
     values = ["Name", "aws:autoscaling:groupName"]
@@ -6,6 +6,6 @@ data "aws_autoscaling_groups" "nodes" {
 
   filter {
     name   = "value"
-    values = ["${var.instance_role_name}"]
+    values = ["${var.auto_scaling_groups}"]
   }
 }

--- a/infra/terraform/modules/ec2_cluster_autoscaler_policy/iam.tf
+++ b/infra/terraform/modules/ec2_cluster_autoscaler_policy/iam.tf
@@ -18,7 +18,7 @@ data "aws_iam_policy_document" "policy" {
       "autoscaling:TerminateInstanceInAutoScalingGroup",
     ]
 
-    resources = ["${data.aws_autoscaling_groups.nodes.arns}"]
+    resources = ["${data.aws_autoscaling_groups.asgs.arns}"]
   }
 }
 

--- a/infra/terraform/modules/ec2_cluster_autoscaler_policy/variables.tf
+++ b/infra/terraform/modules/ec2_cluster_autoscaler_policy/variables.tf
@@ -4,3 +4,7 @@ variable "instance_role_name" {
 }
 
 variable "policy_name" {}
+
+variable "auto_scaling_groups" {
+  type = "list"
+}

--- a/infra/terraform/platform/main.tf
+++ b/infra/terraform/platform/main.tf
@@ -144,4 +144,9 @@ module "cluster_autoscaler" {
 
   policy_name        = "${terraform.workspace}-cluster-autoscaler"
   instance_role_name = ["nodes.${terraform.workspace}.${data.terraform_remote_state.global.platform_root_domain}"]
+
+  auto_scaling_groups = [
+    "nodes.${terraform.workspace}.${data.terraform_remote_state.global.platform_root_domain}",
+    "highmem-nodes.${terraform.workspace}.${data.terraform_remote_state.global.platform_root_domain}",
+  ]
 }


### PR DESCRIPTION
[Trello](https://trello.com/c/ivZAkPne)

Relates to [PR](https://github.com/ministryofjustice/analytics-platform-config/pull/110)

Small changes to module to:
- Make it a little more explicit by adding another variable for ASGs
- Allow for adding autoscaling groups that do not have similar name as the role the policy will be attached to.

Also allowing Cluster autoscaler to manage the `highmem` autoscaling group
