### PR TITLE
Scale highmem from 0

### DIFF
--- a/infra/terraform/modules/ec2_cluster_autoscaler_policy/iam.tf
+++ b/infra/terraform/modules/ec2_cluster_autoscaler_policy/iam.tf
@@ -5,6 +5,8 @@ data "aws_iam_policy_document" "policy" {
     actions = [
       "autoscaling:DescribeAutoScalingGroups",
       "autoscaling:DescribeAutoScalingInstances",
+      "autoscaling:DescribeLaunchConfigurations",
+      "autoscaling:DescribeTags",
     ]
 
     resources = ["*"]


### PR DESCRIPTION
Cluster Autoscaler was missing some of the permissions to scale an autoscaling
group from 0.

