### PR TITLE
Merging this PR will add lookup table user and bucket

### DIFF
--- a/infra/terraform/global/iam_upload_users.tf
+++ b/infra/terraform/global/iam_upload_users.tf
@@ -29,3 +29,11 @@ module "laa_cla_upload_user" {
   org_name          = "laa"
   system_name       = "cla"
 }
+
+module "lookup_upload_user" {
+  source = "../modules/data_upload_user"
+
+  upload_bucket_arn = "${aws_s3_bucket.lookups.arn}"
+  org_name          = "ap"
+  system_name       = "lookup"
+}

--- a/infra/terraform/global/iam_upload_users.tf
+++ b/infra/terraform/global/iam_upload_users.tf
@@ -31,9 +31,8 @@ module "laa_cla_upload_user" {
 }
 
 module "lookup_upload_user" {
-  source = "../modules/data_upload_user"
+  source = "../modules/data_bucket_upload_user"
 
   upload_bucket_arn = "${aws_s3_bucket.lookups.arn}"
-  org_name          = "ap"
   system_name       = "lookup"
 }

--- a/infra/terraform/global/s3.tf
+++ b/infra/terraform/global/s3.tf
@@ -33,3 +33,21 @@ resource "aws_s3_bucket" "uploads" {
     }
   }
 }
+
+resource "aws_s3_bucket" "lookups" {
+  bucket = "${var.lookups_bucket_name}"
+  region = "${var.region}"
+  acl    = "private"
+
+  versioning {
+    enabled = true
+  }
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+}

--- a/infra/terraform/global/variables.tf
+++ b/infra/terraform/global/variables.tf
@@ -18,7 +18,7 @@ variable "uploads_bucket_name" {
 }
 
 variable "lookups_bucket_name" {
-  default = "lokup-tables"
+  default = "moj-analytics-lookup-tables"
 }
 
 variable "global_cloudtrail_bucket_name" {

--- a/infra/terraform/global/variables.tf
+++ b/infra/terraform/global/variables.tf
@@ -17,6 +17,10 @@ variable "uploads_bucket_name" {
   default = "mojap-land"
 }
 
+variable "lookups_bucket_name" {
+  default = "lokup-tables"
+}
+
 variable "global_cloudtrail_bucket_name" {
   default = "moj-analytics-global-cloudtrail"
 }

--- a/infra/terraform/modules/data_bucket_upload_user/iam.tf
+++ b/infra/terraform/modules/data_bucket_upload_user/iam.tf
@@ -26,6 +26,19 @@ data "aws_iam_policy_document" "system_user_s3_upload_readwrite" {
       "${var.upload_bucket_arn}/",
     ]
   }
+
+  statement {
+    actions = [
+      "athena:*",
+      "glue:*",
+    ]
+
+    effect = "Allow"
+
+    resources = [
+      "*",
+    ]
+  }
 }
 
 resource "aws_iam_policy" "system_user_s3_readwrite" {
@@ -52,6 +65,19 @@ data "aws_iam_policy_document" "system_policy_s3_readonly" {
 
     resources = [
       "${var.upload_bucket_arn}/",
+    ]
+  }
+
+  statement {
+    actions = [
+      "athena:*",
+      "glue:*",
+    ]
+
+    effect = "Allow"
+
+    resources = [
+      "*",
     ]
   }
 }

--- a/infra/terraform/modules/data_bucket_upload_user/iam.tf
+++ b/infra/terraform/modules/data_bucket_upload_user/iam.tf
@@ -1,0 +1,63 @@
+resource "aws_iam_user" "system" {
+  name = "${var.system_name}_uploader"
+  path = "/uploaders/"
+}
+
+resource "aws_iam_access_key" "system_user" {
+  user = "${aws_iam_user.system.name}"
+}
+
+data "aws_iam_policy_document" "system_user_s3_upload_readwrite" {
+  statement {
+    actions = [
+      "s3:ListMultipartUploadParts",
+      "s3:GetObject",
+      "s3:GetObjectAcl",
+      "s3:GetObjectVersion",
+      "s3:PutObject",
+      "s3:PutObjectAcl",
+      "s3:PutObjectVersion",
+      "s3:RestoreObject",
+    ]
+
+    effect = "Allow"
+
+    resources = [
+      "${var.upload_bucket_arn}/",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "system_user_s3_readwrite" {
+  name   = "${var.system_name}_s3_upload_readwrite"
+  path   = "/uploaders/${var.system_name}/"
+  policy = "${data.aws_iam_policy_document.system_user_s3_upload_readwrite.json}"
+}
+
+resource "aws_iam_user_policy_attachment" "system_user_s3_upload" {
+  user       = "${aws_iam_user.system.name}"
+  policy_arn = "${aws_iam_policy.system_user_s3_readwrite.arn}"
+}
+
+data "aws_iam_policy_document" "system_policy_s3_readonly" {
+  statement {
+    actions = [
+      "s3:GetObject",
+      "s3:GetObjectAcl",
+      "s3:GetObjectVersion",
+      "s3:ListBucket",
+    ]
+
+    effect = "Allow"
+
+    resources = [
+      "${var.upload_bucket_arn}/",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "system_user_s3_readonly" {
+  name   = "${var.system_name}_s3_readonly"
+  path   = "/uploaders/${var.system_name}/"
+  policy = "${data.aws_iam_policy_document.system_policy_s3_readonly.json}"
+}

--- a/infra/terraform/modules/data_bucket_upload_user/outputs.tf
+++ b/infra/terraform/modules/data_bucket_upload_user/outputs.tf
@@ -1,0 +1,7 @@
+output "access_key_id" {
+  value = "${aws_iam_access_key.system_user.id}"
+}
+
+output "access_key_secret" {
+  value = "${aws_iam_access_key.system_user.secret}"
+}

--- a/infra/terraform/modules/data_bucket_upload_user/variables.tf
+++ b/infra/terraform/modules/data_bucket_upload_user/variables.tf
@@ -1,0 +1,2 @@
+variable "upload_bucket_arn" {}
+variable "system_name" {}


### PR DESCRIPTION
## What

It creates a new bucket to add lookup tables in to and a new user with write access to those buckets. It also creates a new IAM policy for reading the buckets. 

This is so we can create a concourse job that will copy data from `lookup_` prefixed github repos to this bucket. This can be used for general data so there is a single source for data that is used across departments.

## How to review

1. There is a bucket called `moj-analytics-lookup-table` created
2. There is a user called `lookup_upload_user` created that can write/delete bucket contents
3. There is a IAM policy called `lookup_s3_readonly` created that can read bucket contents


