### PR TITLE
 Merging this PR will add assume role from glue for the lookup tables job

### DIFF
--- a/infra/terraform/modules/data_bucket_upload_user/iam.tf
+++ b/infra/terraform/modules/data_bucket_upload_user/iam.tf
@@ -9,21 +9,45 @@ resource "aws_iam_access_key" "system_user" {
 
 data "aws_iam_policy_document" "system_user_s3_upload_readwrite" {
   statement {
+    sid = "ListUploadBucket"
+
     actions = [
-      "s3:ListMultipartUploadParts",
-      "s3:GetObject",
-      "s3:GetObjectAcl",
-      "s3:GetObjectVersion",
-      "s3:PutObject",
-      "s3:PutObjectAcl",
-      "s3:PutObjectVersion",
-      "s3:RestoreObject",
+      "s3:ListBucket",
     ]
 
     effect = "Allow"
 
     resources = [
-      "${var.upload_bucket_arn}/",
+      "${var.upload_bucket_arn}",
+      "${var.upload_bucket_arn}/*",
+    ]
+  }
+
+  statement {
+    sid = "ReadWriteUploadBucket"
+
+    actions = [
+      "s3:GetObject",
+      "s3:GetObjectAcl",
+      "s3:GetObjectVersion",
+      "s3:DeleteObject",
+      "s3:DeleteObjectVersion",
+      "s3:PutObject",
+      "s3:PutObjectAcl",
+      "s3:PutObjectVersion",
+      "s3:RestoreObject",
+      "s3:GetBucketLocation",
+      "s3:ListBucketMultipartUploads",
+      "s3:ListMultipartUploadParts",
+      "s3:AbortMultipartUpload",
+      "s3:CreateBucket",
+    ]
+
+    effect = "Allow"
+
+    resources = [
+      "${var.upload_bucket_arn}",
+      "${var.upload_bucket_arn}/*",
     ]
   }
 
@@ -78,19 +102,60 @@ resource "aws_iam_user_policy_attachment" "system_user_s3_upload" {
   policy_arn = "${aws_iam_policy.system_user_s3_readwrite.arn}"
 }
 
+resource "aws_iam_role" "lookups_job_role" {
+  name = "lookups_job_role"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": ["glue.amazonaws.com", "ec2.amazonaws.com"]
+      },
+      "Effect": "Allow",
+      "Sid": "Assumejob"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "lookups_job_role_attatchment" {
+  policy_arn = "${aws_iam_policy.system_user_s3_readwrite.arn}"
+  role       = "${aws_iam_role.lookups_job_role.name}"
+}
+
 data "aws_iam_policy_document" "system_policy_s3_readonly" {
   statement {
+    sid = "ListUploadBucketRO"
+
     actions = [
-      "s3:GetObject",
-      "s3:GetObjectAcl",
-      "s3:GetObjectVersion",
       "s3:ListBucket",
     ]
 
     effect = "Allow"
 
     resources = [
-      "${var.upload_bucket_arn}/",
+      "${var.upload_bucket_arn}",
+    ]
+  }
+
+  statement {
+    sid = "ReadOnlyBucketRo"
+
+    actions = [
+      "s3:GetObject",
+      "s3:GetObjectAcl",
+      "s3:GetObjectVersion",
+    ]
+
+    effect = "Allow"
+
+    resources = [
+      "${var.upload_bucket_arn}",
+      "${var.upload_bucket_arn}/*",
     ]
   }
 
@@ -140,31 +205,6 @@ resource "aws_iam_policy" "system_user_s3_readonly" {
   policy = "${data.aws_iam_policy_document.system_policy_s3_readonly.json}"
 }
 
-resource "aws_iam_role" "lookups_job_role" {
-  name = "lookups_job_role"
-
-  assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": "sts:AssumeRole",
-      "Principal": {
-        "Service": ["glue.amazonaws.com", "ec2.amazonaws.com"]
-      },
-      "Effect": "Allow",
-      "Sid": ""
-    }
-  ]
-}
-EOF
-}
-
-resource "aws_iam_role_policy_attachment" "lookups_job_role_attatchment" {
-  policy_arn = "${aws_iam_policy.system_user_s3_readwrite.arn}"
-  role       = "${aws_iam_role.lookups_job_role.name}"
-}
-
 resource "aws_iam_role" "lookups_user_role" {
   name = "lookups_user_role"
 
@@ -178,7 +218,7 @@ resource "aws_iam_role" "lookups_user_role" {
         "Service": ["glue.amazonaws.com", "ec2.amazonaws.com"]
       },
       "Effect": "Allow",
-      "Sid": ""
+      "Sid": "AssumeUser"
     }
   ]
 }

--- a/infra/terraform/modules/data_bucket_upload_user/iam.tf
+++ b/infra/terraform/modules/data_bucket_upload_user/iam.tf
@@ -39,6 +39,32 @@ data "aws_iam_policy_document" "system_user_s3_upload_readwrite" {
       "*",
     ]
   }
+
+  statement {
+    actions = [
+      "cloudwatch:PutMetricData",
+    ]
+
+    effect = "Allow"
+
+    resources = [
+      "*",
+    ]
+  }
+
+  statement {
+    actions = [
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+    ]
+
+    effect = "Allow"
+
+    resources = [
+      "arn:aws:logs:*:*:/aws-glue/*",
+    ]
+  }
 }
 
 resource "aws_iam_policy" "system_user_s3_readwrite" {
@@ -80,10 +106,86 @@ data "aws_iam_policy_document" "system_policy_s3_readonly" {
       "*",
     ]
   }
+
+  statement {
+    actions = [
+      "cloudwatch:PutMetricData",
+    ]
+
+    effect = "Allow"
+
+    resources = [
+      "*",
+    ]
+  }
+
+  statement {
+    actions = [
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+    ]
+
+    effect = "Allow"
+
+    resources = [
+      "arn:aws:logs:*:*:/aws-glue/*",
+    ]
+  }
 }
 
 resource "aws_iam_policy" "system_user_s3_readonly" {
   name   = "${var.system_name}_s3_readonly"
   path   = "/uploaders/${var.system_name}/"
   policy = "${data.aws_iam_policy_document.system_policy_s3_readonly.json}"
+}
+
+resource "aws_iam_role" "lookups_job_role" {
+  name = "lookups_job_role"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": ["glue.amazonaws.com", "ec2.amazonaws.com"]
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "lookups_job_role_attatchment" {
+  policy_arn = "${aws_iam_policy.system_user_s3_readwrite.arn}"
+  role       = "${aws_iam_role.lookups_job_role.name}"
+}
+
+resource "aws_iam_role" "lookups_user_role" {
+  name = "lookups_user_role"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": ["glue.amazonaws.com", "ec2.amazonaws.com"]
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "lookups_user_role_attatchment" {
+  policy_arn = "${aws_iam_policy.system_user_s3_readonly.arn}"
+  role       = "${aws_iam_role.lookups_user_role.name}"
 }


### PR DESCRIPTION

## What

Added roles so the glue job on the lookup tables can assume the `lookups_job_role` so it has required access. Also added a role for uses to assume with read access `lookups_user_role`

## How to review

1. `lookups_job_role` is created
2.  lookups_user_role is created
3.  Policy changed to allow for logging and cloudwatch


