### PR TITLE
Allow the lookup upload user to pass role to the aws glue job

### DIFF
--- a/infra/terraform/modules/data_bucket_upload_user/iam.tf
+++ b/infra/terraform/modules/data_bucket_upload_user/iam.tf
@@ -89,6 +89,18 @@ data "aws_iam_policy_document" "system_user_s3_upload_readwrite" {
       "arn:aws:logs:*:*:/aws-glue/*",
     ]
   }
+
+  statement {
+    actions = [
+      "iam:PassRole",
+    ]
+
+    effect = "Allow"
+
+    resources = [
+      "arn:aws:iam::*:role/lookups_job_role",
+    ]
+  }
 }
 
 resource "aws_iam_policy" "system_user_s3_readwrite" {


### PR DESCRIPTION
Allow lookup user to pass glue job role to glue job

## How to review

1. `lookup_uploader` user now has `iam:PassRole` for role `arn:aws:iam::*:role/lookups_job_role`
