### PR TITLE
Adds upload user for HMCTS Azure Platform

### DIFF
--- a/infra/terraform/global/iam_upload_users.tf
+++ b/infra/terraform/global/iam_upload_users.tf
@@ -1,3 +1,11 @@
+module "hmcts_upload_user" {
+  source = "../modules/data_upload_user"
+
+  upload_bucket_arn = "${aws_s3_bucket.uploads.arn}"
+  org_name          = "hmcts"
+  system_name       = "azure"
+}
+
 module "hmpps_nomis_upload_user" {
   source = "../modules/data_upload_user"
 

--- a/infra/terraform/global/outputs.tf
+++ b/infra/terraform/global/outputs.tf
@@ -93,3 +93,11 @@ output "lookup_upload_user_access_key_id" {
 output "lookup_upload_user_access_key_secret" {
   value = "${module.lookup_upload_user.access_key_secret}"
 }
+
+output "hmcts_upload_user_access_key_id" {
+  value = "${module.hmcts_upload_user.access_key_id}"
+}
+
+output "hmcts_upload_user_access_key_secret" {
+  value = "${module.hmcts_upload_user.access_key_secret}"
+}


### PR DESCRIPTION
## What

Adds upload user for HMCTS Azure Platform so they can upload data on to the platform

## How to review

1. See if user is created and get the outputs from the apply command
