### PR TITLE
Upload user policy

### DIFF
--- a/infra/terraform/global/outputs.tf
+++ b/infra/terraform/global/outputs.tf
@@ -109,3 +109,11 @@ output "ppas_mdt_upload_access_key_id" {
 output "ppas_mdt_upload_access_key_secret" {
   value = "${module.ppas_mdt_upload_user.access_key_secret}"
 }
+
+output "laa_cla_upload_user_access_key_id" {
+  value = "${module.laa_cla_upload_user.access_key_id}"
+}
+
+output "laa_cla_upload_user_access_key_secret" {
+  value = "${module.laa_cla_upload_user.access_key_secret}"
+}

--- a/infra/terraform/modules/data_upload_user/iam.tf
+++ b/infra/terraform/modules/data_upload_user/iam.tf
@@ -17,7 +17,7 @@ data "aws_iam_policy_document" "system_user_s3_upload_writeonly" {
     effect = "Allow"
 
     resources = [
-      "${var.upload_bucket_arn}/${var.org_name}/${var.system_name}/",
+      "${var.upload_bucket_arn}/${var.org_name}/${var.system_name}/*",
     ]
   }
 }


### PR DESCRIPTION
## What

Upload user previously only had PutObjewct perms on `aws:arn:::bucket/path/`. Need to add a `*` to the end of it to allow uploads to files/paths within that path.

## How to review

1.  `*` added to policy bucket arn in PutObject 
