### PR TITLE
Remove OIDC migration IAM role

### DIFF
--- a/infra/terraform/modules/control_panel_api/role.tf
+++ b/infra/terraform/modules/control_panel_api/role.tf
@@ -147,17 +147,6 @@ resource "aws_iam_policy" "control_panel_api" {
       "Resource": [
         "arn:aws:iam::${var.account_id}:*"
       ]
-    },
-    {
-      "Sid": "TemporaryForOIDCMigration",
-      "Effect": "Allow",
-      "Action": [
-        "iam:GetRole",
-        "iam:UpdateAssumeRolePolicy"
-      ],
-      "Resource": [
-        "arn:aws:iam::${var.account_id}:role/${var.env}_user_*"
-      ]
     }
   ]
 }


### PR DESCRIPTION
TemporaryForOIDCMigration IAM role was introduced in:
https://github.com/ministryofjustice/analytics-platform-ops/pull/124
and according to that it should no longer be needed.

It gives cpanel a concerning level power in AWS.