### PR TITLE
Postgres was auto-upgraded - avoid terraform complaining

### DIFF
--- a/infra/terraform/modules/control_panel_api/db.tf
+++ b/infra/terraform/modules/control_panel_api/db.tf
@@ -16,19 +16,20 @@ resource "aws_security_group" "control_panel_db" {
 }
 
 resource "aws_db_instance" "control_panel_db" {
-  identifier              = "${var.env}-control-panel-db"
-  storage_type            = "${var.storage_type}"
-  allocated_storage       = "${var.allocated_storage}"
-  engine                  = "postgres"
-  engine_version          = "9.6.6"
-  instance_class          = "db.t2.micro"
-  name                    = "controlpanel"
-  username                = "${var.db_username}"
-  password                = "${var.db_password}"
-  db_subnet_group_name    = "${aws_db_subnet_group.control_panel_db.name}"
-  vpc_security_group_ids  = ["${aws_security_group.control_panel_db.*.id}"]
-  backup_retention_period = 35
-  backup_window           = "22:00-23:59"
-  skip_final_snapshot     = true
-  maintenance_window      = "Sat:01:00-Sat:03:00"
+  identifier                 = "${var.env}-control-panel-db"
+  storage_type               = "${var.storage_type}"
+  allocated_storage          = "${var.allocated_storage}"
+  engine                     = "postgres"
+  engine_version             = "9.6"
+  auto_minor_version_upgrade = true
+  instance_class             = "db.t2.micro"
+  name                       = "controlpanel"
+  username                   = "${var.db_username}"
+  password                   = "${var.db_password}"
+  db_subnet_group_name       = "${aws_db_subnet_group.control_panel_db.name}"
+  vpc_security_group_ids     = ["${aws_security_group.control_panel_db.*.id}"]
+  backup_retention_period    = 35
+  backup_window              = "22:00-23:59"
+  skip_final_snapshot        = true
+  maintenance_window         = "Sat:01:00-Sat:03:00"
 }


### PR DESCRIPTION
AWS does minor upgrades to RDS instances. Recently it upgraded postgres
from 9.6.6 to 9.6.11. The control panel db was specified exactly to 9.6.6
in terraform, so "terraform apply" wanted to downgrade it again. To avoid
this we simply don't specify the last part of the version and it is happy.

Might as well also explicitly set auto_minor_version_upgrade=True, which is
the default, so no change.
