### PR TITLE
Script to remove `idled` label when not idled

### DIFF
--- a/scripts/remove-idled-label-when-unidled.sh
+++ b/scripts/remove-idled-label-when-unidled.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# Remove the `mojanalytics.xyz/idled` label from unidled Deployments
+
+
+set -e
+
+
+kubectl get deployment --all-namespaces -l"mojanalytics.xyz/idled" --no-headers -o=custom-columns=NAME:.metadata.name,NS:.metadata.namespace,REPLICAS:.spec.replicas | while read -r DEPLOY
+do
+    replicas=`echo $DEPLOY | cut -d' ' -f3`
+    if [ ! "$replicas" = "0" ]; then
+        ns=`echo $DEPLOY | cut -d' ' -f2`
+        deploy=`echo $DEPLOY | cut -d' ' -f1`
+
+        kubectl --namespace=${ns} patch deployment ${deploy} --type='json' -p="[{\"op\": \"remove\", \"path\": \"/metadata/labels/mojanalytics.xyz~1idled\"}]" && echo "Removed 'mojanalytics.xyz/idled' label from Deployment '$deploy' in namespace '${ns}' '"
+    fi
+
+done;


### PR DESCRIPTION
We have several Deployment which were unidled but whose `idled` label
was not removed.

This script will remove these labels from the `Deployment`s which are
clealy not idled (because they don't have `0` replicas).

**NOTE**: Because this changes only the `Deployment` metadata and not the
pod spec, this will **not** trigger the re-creation of new pods so it
should be safe to run without causing any downtime.

How did this happen?
====================
- the [unidler] uses JSONPatch to remove 2 annotations and this label after
  a `Deployment` is unidled
- we introduced a new annotation which is only added by a new version of
  the idler
- despite all these patch operations being `remove` operations this patch
  fails when the new annotation (or anything) is not already there. This
  is frustrating as it's not very "declarative" and what we'd prefer is
  really for the Kubernetes API to be clever enough to realise that we're
  already in the desired state and *not* fail.

[unidler]: https://github.com/ministryofjustice/analytics-platform-go-unidler/blob/master/app.go#L213


### Ticket
https://trello.com/c/GPstDIzR/198-investigate-why-unidled-deployments-have-idledtrue-label-which-prevents-their-idling