### PR TITLE
Add script to create Auth0 additional connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,9 +223,41 @@ You can now quit the launch process because terraform will do the launch. The im
     7. Under "Identity Provider Metadata" (NOT "Certificate"!) click "download"
     8. Refer to `platform-base` Terraform instructions below for information on configuring Terraform to use SAML signon
 
-##### Auth0 Applications
+##### Connections & Applications
 
-In Auth0 you need to create some Applications.
+In Auth0 you need to create some Connections and Applications.
+
+##### Connections
+
+###### GitHub
+ 1. Click GitHub to set it up
+ 2. Follow: [Connect your app to GitHub](https://auth0.com/docs/connections/social/github)
+    Make sure you create the connection in your organization, not your own account. Complete the Client ID and Client Secret on GitHub.
+ 3. Check these boxes:
+    * Email address
+    * read:user
+    * read:org
+ 4. Click "Save"
+ 5. Click "Applications" tab and switch on all applications that need login, including: auth0-authz, AWS, RStudio, Grafana, Control Panel, kubectl-oidc, Jupyter Lab, Concourse, Airflow, auth0-logs-to-logstash.
+ 6. Click "Save" and "X" to close the dialog.
+####### Google
+1. Set the apps that Google can be used sign in to:
+     1. Still in "Connections" | "Social", click "Google" then "Applications"
+     2. Ensure only these are switched on: Default App, auth0-authz, API Client, auth0-github-deploy, API Explorer Client, API Explorer Application, auth0-logs-to-logstash, Airflow.
+
+###### NOMIS & Other `oauth2` Connections
+To create additional connections like `nomis` there is a script that you can run, follow it's
+own [README](./scripts/auth0connections/README.md) for instructions on how to set it up.
+
+Once it is set up run:
+
+```bash
+./scripts/auth0connections/auth0connections.py -f PATH/to/config/repo/chart-env-config/ENV/auth0connections.yaml create
+```
+
+or the equivalent docker command if you're running it in docker.
+
+###### Applications
 
 ###### kubectl-oidc application
 
@@ -244,20 +276,9 @@ In Auth0 you need to create some Applications.
 7. Click "Connections" tab
 8. Switch OFF "Database" and "Google"
 9. In the side-bar click "Connections" then "Social"
-10. If GitHub is not already ON:
-     1. Click GitHub to set it up
-     2. Follow: [Connect your app to GitHub](https://auth0.com/docs/connections/social/github)
-        Make sure you create the connection in your organization, not your own account. Complete the Client ID and Client Secret on GitHub.
-     3. Check these boxes:
-        * Email address
-        * read:user
-        * read:org
-     4. Click "Save"
-     5. Click "Applications" tab and switch on all applications that need login, including: auth0-authz, AWS, RStudio, Grafana, Control Panel, kubectl-oidc, Jupyter Lab, Concourse, Airflow, auth0-logs-to-logstash.
-     6. Click "Save" and "X" to close the dialog.
-11. Set the apps that Google can be used sign in to:
-     1. Still in "Connections" | "Social", click "Google" then "Applications"
-     2. Ensure only these are switched on: Default App, auth0-authz, API Client, auth0-github-deploy, API Explorer Client, API Explorer Application, auth0-logs-to-logstash, Airflow.
+10. Click GitHub
+     1. Click "Applications" tab and switch on `kubectl-oidc` application
+     1. Click "Save" and "X" to close the dialog.
 
 The Client ID and Client Secret values will be used in various helm chart configurations.
 

--- a/scripts/auth0connections/.dockerignore
+++ b/scripts/auth0connections/.dockerignore
@@ -1,0 +1,1 @@
+.gitignore

--- a/scripts/auth0connections/.gitignore
+++ b/scripts/auth0connections/.gitignore
@@ -1,0 +1,66 @@
+#### joe made this: http://goel.io/joe
+
+#####=== Python ===#####
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+.venv/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+*.iml
+.env
+/.python-version

--- a/scripts/auth0connections/Dockerfile
+++ b/scripts/auth0connections/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.7-alpine
+
+RUN addgroup -g 1000 -S app && \
+    adduser -u 1000 -S app -G app
+
+WORKDIR /home/app/
+USER 1000
+ENV PATH=${PATH}:/home/app/.local/bin
+
+COPY pyproject.toml poetry.lock /home/app/
+RUN pip install --user poetry \
+    && poetry install --no-dev
+
+ADD . .
+ENTRYPOINT ["poetry", "run", "/home/app/auth0connections.py", "-f", "/tmp/values.yaml"]

--- a/scripts/auth0connections/README.md
+++ b/scripts/auth0connections/README.md
@@ -1,0 +1,109 @@
+# Auth0 Connection Creator Script
+
+This script creates auth0 connections that are defined in the `./connections`
+directory.
+
+This should really be done in `terraform` using the auth0 provider, but this has
+already been attempted and couldn't be done as it requires all `apps/clients` linked to
+the connection to be managed by `terraform` too. We allow clients to be created by the
+`cpanel` so every time we ran a terraform apply it would go and delete any `cpanel`
+created `apps/clients`.
+
+This script isn't ideal but I feel it's better than just providing instructions
+about where to click in the auth0 UI or trying to PR the auth0 provider to support
+what we need it to do.
+
+## Running
+
+### Commands
+
+#### `local`
+
+Scan [`./connections`](./connections) and print the defined connections.
+
+example:
+
+```bash
+poetry run ./auth0connections.py -f path/to/values.yaml local
+```
+
+#### `remote`
+
+Make an API call to auth0
+
+example:
+
+```bash
+poetry run ./auth0connections.py -f path/to/values.yaml remote
+```
+
+#### `create`
+
+Create the local connections in Auth0 using the management API.
+
+example:
+
+```bash
+poetry run ./auth0connections.py -f path/to/values.yaml create
+```
+
+## Environment Variables
+
+`AUTH0_TOKEN` - An auth0 management v3 API token for you tenant, you can get one
+by visiting this page: [https://manage.auth0.com/#/apis/management/explorer](https://manage.auth0.com/#/apis/management/explorer).
+
+`AUTH0_DOMAIN` - Domain of your auth0 tenant.
+
+Feel free to give it a short TTL as it will only be required while you
+run this script.
+
+### Create `.env` file
+
+If you put the environment variables in an `.env` file then using Docker will be
+easier.
+
+```
+AUTH0_TOKEN=eyJ…oeafmoaeo
+AUTH0_DOMAIN=your-auth0-domain.eu.auth0.com
+```
+
+## Values
+
+See the [example values file](./values.example.yaml) for the values you need to provide when creating a
+client.
+
+### With Docker
+
+#### Build
+
+```bash
+docker build . -t a0c
+```
+
+#### Execute Script
+
+```bash
+ docker run --env-file=.env -v ../../../analytics-platform-config/chart-env-config/dev/auth0connections.yaml:/tmp/config.yaml a0c local
+```
+
+### Without Docker
+
+Make sure you have [`poetry` installed](https://poetry.eustace.io/docs/#installation) then run:
+
+```bash
+poetry install
+poetry run ./auth0connections.py -f path/to/values.yaml COMMAND
+```
+
+## Specify Connections
+
+To define a new connection:
+
+-   make a directory under [`./connections`](./connections)
+-   in that directory make a file called `config.yaml` with json body of
+    your connection. You can use jinja templating to interpolate variables from the `values.yaml`
+    file.
+-   (optional) If you want to make embed a javacript file in the `options.script` part of your connection,
+    e.g. a `fetchUserProfile.js` script for an `oauth2` connection then create a file called `fetchUserProfile.js` alongside
+    the config.yaml. You can also interpolate values using `jinja2` syntax here. See the [nomis](./connections/nomis)
+    for a real example.

--- a/scripts/auth0connections/auth0connections.py
+++ b/scripts/auth0connections/auth0connections.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python
+import base64
+import functools
+from collections import defaultdict
+from pathlib import Path
+from pprint import pprint
+
+import click
+import yaml
+from auth0.v3.management import Auth0
+from environs import Env
+from jinja2 import Environment
+
+env = Env()
+env.read_env()  # read .env file, if it exists
+jinja_env = Environment()
+jinja_env.filters["base64enc"] = lambda x: base64.urlsafe_b64encode(
+    x.encode("utf8")
+).decode()
+
+
+AUTH0_TOKEN = env("AUTH0_TOKEN")
+AUTH0_DOMAIN = env("AUTH0_DOMAIN")
+
+
+@functools.lru_cache(maxsize=1)
+def get_client():
+    return Auth0(AUTH0_DOMAIN, AUTH0_TOKEN)
+
+
+def render_local_connections(config):
+    connections = {}
+    connections_root = Path(__file__).cwd() / Path("connections")
+    connection_dirs = [entry for entry in connections_root.iterdir() if entry.is_dir()]
+
+    for connection in connection_dirs:
+        connection_name = connection.stem
+        scripts = connection.glob("*.js")
+        script_templates = {
+            x.stem: jinja_env.from_string(x.open(encoding="utf8").read())
+            for x in scripts
+        }
+        scripts_rendered = {}
+        for name, template in script_templates.items():
+            scripts_rendered[name] = template.render(**config.get(connection_name))
+
+        with (connection / Path("config.yaml")).open("r") as connection_config:
+            yaml_rendered = jinja_env.from_string(connection_config.read()).render(
+                **config.get(connection_name)
+            )
+            body = yaml.safe_load(yaml_rendered) or defaultdict(dict)
+            body["options"]["scripts"] = scripts_rendered
+            connections[connection_name] = body
+
+    return connections
+
+
+@click.group()
+@click.pass_context
+@click.option("-f", "--config-file", type=click.File("r"), required=True)
+def cli(ctx, config_file):
+    ctx.ensure_object(dict)
+    ctx.obj["config_file"] = yaml.safe_load(config_file)
+    config_file.close()
+
+
+@cli.command()
+def remote():
+    """
+    Show a list of existing connections on auth0
+    """
+    click.echo("Remote connections:")
+    client = get_client()
+    click.echo(yaml.safe_dump(client.connections.all()))
+
+
+@cli.command()
+@click.pass_context
+def local(ctx):
+    """
+    Show defined connections
+    """
+    click.echo("Local connections:")
+    click.echo(yaml.safe_dump(render_local_connections(ctx.obj["config_file"])))
+
+
+@cli.command()
+@click.pass_context
+def create(ctx):
+    click.echo("Creating connections:")
+    rendered_connections = render_local_connections(ctx.obj["config_file"])
+    client = get_client()
+    remote_connections = [x["name"] for x in client.connections.all()]
+    for connection_name, body in rendered_connections.items():
+        if not connection_name in remote_connections:
+            click.echo(f"Creating {connection_name}")
+            resp = client.connections.create(body)
+            click.echo(pprint(resp))
+        else:
+            click.echo(
+                f"Skipping: {connection_name} as it already exists. Delete it "
+                f"from auth0 if you want this script to recreate it"
+            )
+
+
+if __name__ == "__main__":
+    cli()

--- a/scripts/auth0connections/connections/nomis/config.yaml
+++ b/scripts/auth0connections/connections/nomis/config.yaml
@@ -1,0 +1,15 @@
+---
+options:
+    scripts: {}
+    client_id: {{client_id}}
+    client_secret: {{client_secret}}
+    authorizationURL: {{gateway_url}}{{authorize_endpoint}}
+    tokenURL: {{gateway_url}}{{token_endpoint}}
+    scope: ''
+    customHeaders:
+        Authorization: Basic {{ (client_id + ':' + client_secret)|base64enc }}
+        Content-Type: application/json
+strategy: oauth2
+name: nomis
+is_domain_connection: false
+enabled_clients: []

--- a/scripts/auth0connections/connections/nomis/fetchUserProfile.js
+++ b/scripts/auth0connections/connections/nomis/fetchUserProfile.js
@@ -1,0 +1,34 @@
+function(accessToken, ctx, cb) {
+  var base_url = "{{gateway_url}}";
+  var user_endpoint = "{{user_endpoint}}";
+  var user_profile_url = base_url + user_endpoint;
+
+  // call oauth2 API with the accesstoken and create the profile
+  request.get(
+    user_profile_url,
+    {
+      headers: {
+        Authorization: "Bearer " + accessToken
+      }
+    },
+    function(err, resp, body) {
+      if (err) {
+        cb(err);
+        return;
+      }
+      if (!/^2/.test("" + resp.statusCode)) {
+        cb(body);
+        return;
+      }
+      var parsedBody = JSON.parse(body);
+      var profile = {
+        user_id: parsedBody.staffId,
+        nickname: parsedBody.name,
+        username: parsedBody.username,
+        blocked: !parsedBody.active,
+        activeCaseLoadId: parsedBody.activeCaseLoadId
+      };
+      cb(null, profile);
+    }
+  );
+}

--- a/scripts/auth0connections/poetry.lock
+++ b/scripts/auth0connections/poetry.lock
@@ -1,0 +1,314 @@
+[[package]]
+category = "dev"
+description = "Disable App Nap on OS X 10.9"
+marker = "sys_platform == \"darwin\""
+name = "appnope"
+optional = false
+python-versions = "*"
+version = "0.1.0"
+
+[[package]]
+category = "main"
+description = "Auth0 Python SDK"
+name = "auth0-python"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*"
+version = "3.7.2"
+
+[package.dependencies]
+requests = "*"
+
+[[package]]
+category = "dev"
+description = "Specifications for callback functions passed in to an API"
+name = "backcall"
+optional = false
+python-versions = "*"
+version = "0.1.0"
+
+[[package]]
+category = "main"
+description = "Python package for providing Mozilla's CA Bundle."
+name = "certifi"
+optional = false
+python-versions = "*"
+version = "2019.3.9"
+
+[[package]]
+category = "main"
+description = "Universal encoding detector for Python 2 and 3"
+name = "chardet"
+optional = false
+python-versions = "*"
+version = "3.0.4"
+
+[[package]]
+category = "main"
+description = "Composable command line interface toolkit"
+name = "click"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "7.0"
+
+[[package]]
+category = "dev"
+description = "Cross-platform colored terminal text."
+marker = "sys_platform == \"win32\""
+name = "colorama"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "0.4.1"
+
+[[package]]
+category = "dev"
+description = "Better living through Python with decorators"
+name = "decorator"
+optional = false
+python-versions = ">=2.6, !=3.0.*, !=3.1.*"
+version = "4.4.0"
+
+[[package]]
+category = "main"
+description = "simplified environment variable parsing"
+name = "environs"
+optional = false
+python-versions = "*"
+version = "4.1.3"
+
+[package.dependencies]
+marshmallow = ">=2.7.0"
+python-dotenv = "*"
+
+[[package]]
+category = "main"
+description = "Internationalized Domain Names in Applications (IDNA)"
+name = "idna"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "2.8"
+
+[[package]]
+category = "dev"
+description = "IPython: Productive Interactive Computing"
+name = "ipython"
+optional = false
+python-versions = ">=3.5"
+version = "7.5.0"
+
+[package.dependencies]
+appnope = "*"
+backcall = "*"
+colorama = "*"
+decorator = "*"
+jedi = ">=0.10"
+pexpect = "*"
+pickleshare = "*"
+prompt-toolkit = ">=2.0.0,<2.1.0"
+pygments = "*"
+setuptools = ">=18.5"
+traitlets = ">=4.2"
+
+[[package]]
+category = "dev"
+description = "Vestigial utilities from IPython"
+name = "ipython-genutils"
+optional = false
+python-versions = "*"
+version = "0.2.0"
+
+[[package]]
+category = "dev"
+description = "An autocompletion tool for Python that can be used for text editors."
+name = "jedi"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "0.13.3"
+
+[package.dependencies]
+parso = ">=0.3.0"
+
+[[package]]
+category = "main"
+description = "A small but fast and easy to use stand-alone template engine written in pure python."
+name = "jinja2"
+optional = false
+python-versions = "*"
+version = "2.10.1"
+
+[package.dependencies]
+MarkupSafe = ">=0.23"
+
+[[package]]
+category = "main"
+description = "Safely add untrusted strings to HTML/XML markup."
+name = "markupsafe"
+optional = false
+python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*"
+version = "1.1.1"
+
+[[package]]
+category = "main"
+description = "A lightweight library for converting complex datatypes to and from native Python datatypes."
+name = "marshmallow"
+optional = false
+python-versions = "*"
+version = "2.19.2"
+
+[[package]]
+category = "dev"
+description = "A Python Parser"
+name = "parso"
+optional = false
+python-versions = "*"
+version = "0.4.0"
+
+[[package]]
+category = "dev"
+description = "Pexpect allows easy control of interactive console applications."
+marker = "sys_platform != \"win32\""
+name = "pexpect"
+optional = false
+python-versions = "*"
+version = "4.7.0"
+
+[package.dependencies]
+ptyprocess = ">=0.5"
+
+[[package]]
+category = "dev"
+description = "Tiny 'shelve'-like database with concurrency support"
+name = "pickleshare"
+optional = false
+python-versions = "*"
+version = "0.7.5"
+
+[[package]]
+category = "dev"
+description = "Library for building powerful interactive command lines in Python"
+name = "prompt-toolkit"
+optional = false
+python-versions = "*"
+version = "2.0.9"
+
+[package.dependencies]
+six = ">=1.9.0"
+wcwidth = "*"
+
+[[package]]
+category = "dev"
+description = "Run a subprocess in a pseudo terminal"
+marker = "sys_platform != \"win32\""
+name = "ptyprocess"
+optional = false
+python-versions = "*"
+version = "0.6.0"
+
+[[package]]
+category = "dev"
+description = "Pygments is a syntax highlighting package written in Python."
+name = "pygments"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "2.4.2"
+
+[[package]]
+category = "main"
+description = "Add .env support to your django/flask apps in development and deployments"
+name = "python-dotenv"
+optional = false
+python-versions = "*"
+version = "0.10.2"
+
+[[package]]
+category = "main"
+description = "YAML parser and emitter for Python"
+name = "pyyaml"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "5.1"
+
+[[package]]
+category = "main"
+description = "Python HTTP for Humans."
+name = "requests"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "2.22.0"
+
+[package.dependencies]
+certifi = ">=2017.4.17"
+chardet = ">=3.0.2,<3.1.0"
+idna = ">=2.5,<2.9"
+urllib3 = ">=1.21.1,<1.25.0 || >1.25.0,<1.25.1 || >1.25.1,<1.26"
+
+[[package]]
+category = "dev"
+description = "Python 2 and 3 compatibility utilities"
+name = "six"
+optional = false
+python-versions = ">=2.6, !=3.0.*, !=3.1.*"
+version = "1.12.0"
+
+[[package]]
+category = "dev"
+description = "Traitlets Python config system"
+name = "traitlets"
+optional = false
+python-versions = "*"
+version = "4.3.2"
+
+[package.dependencies]
+decorator = "*"
+ipython-genutils = "*"
+six = "*"
+
+[[package]]
+category = "main"
+description = "HTTP library with thread-safe connection pooling, file post, and more."
+name = "urllib3"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, <4"
+version = "1.25.3"
+
+[[package]]
+category = "dev"
+description = "Measures number of Terminal column cells of wide-character codes"
+name = "wcwidth"
+optional = false
+python-versions = "*"
+version = "0.1.7"
+
+[metadata]
+content-hash = "58a32ce5a339f0f270497dc6aa8ee1a521d4dc67eafc9a4d73bdb0cbb084ae68"
+python-versions = "^3.7"
+
+[metadata.hashes]
+appnope = ["5b26757dc6f79a3b7dc9fab95359328d5747fcb2409d331ea66d0272b90ab2a0", "8b995ffe925347a2138d7ac0fe77155e4311a0ea6d6da4f5128fe4b3cbe5ed71"]
+auth0-python = ["098ce1275f1e276e45c7d7fa4e8af1257993b2ed3ec19a37090230df3d6296c5", "d70f3e666787b69cfeaf6b270c1050364da0e65308a949f3255bb1fe5553f2be"]
+backcall = ["38ecd85be2c1e78f77fd91700c76e14667dc21e2713b63876c0eb901196e01e4", "bbbf4b1e5cd2bdb08f915895b51081c041bac22394fdfcfdfbe9f14b77c08bf2"]
+certifi = ["59b7658e26ca9c7339e00f8f4636cdfe59d34fa37b9b04f6f9e9926b3cece1a5", "b26104d6835d1f5e49452a26eb2ff87fe7090b89dfcaee5ea2212697e1e1d7ae"]
+chardet = ["84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae", "fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"]
+click = ["2335065e6395b9e67ca716de5f7526736bfa6ceead690adf616d925bdc622b13", "5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7"]
+colorama = ["05eed71e2e327246ad6b38c540c4a3117230b19679b875190486ddd2d721422d", "f8ac84de7840f5b9c4e3347b3c1eaa50f7e49c2b07596221daec5edaabbd7c48"]
+decorator = ["86156361c50488b84a3f148056ea716ca587df2f0de1d34750d35c21312725de", "f069f3a01830ca754ba5258fde2278454a0b5b79e0d7f5c13b3b97e57d4acff6"]
+environs = ["1b2c326abd06f47a26686a3cee00ee2266dc065f37cbbba2edb6c31c30cd524f", "f49132031384d37386d4e229310473c081bbeb389b65fbb118d91b63f1a1ac5f"]
+idna = ["c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407", "ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c"]
+ipython = ["54c5a8aa1eadd269ac210b96923688ccf01ebb2d0f21c18c3c717909583579a8", "e840810029224b56cd0d9e7719dc3b39cf84d577f8ac686547c8ba7a06eeab26"]
+ipython-genutils = ["72dd37233799e619666c9f639a9da83c34013a73e8bbc79a7a6348d93c61fab8", "eb2e116e75ecef9d4d228fdc66af54269afa26ab4463042e33785b887c628ba8"]
+jedi = ["2bb0603e3506f708e792c7f4ad8fc2a7a9d9c2d292a358fbbd58da531695595b", "2c6bcd9545c7d6440951b12b44d373479bf18123a401a52025cf98563fbd826c"]
+jinja2 = ["065c4f02ebe7f7cf559e49ee5a95fb800a9e4528727aec6f24402a5374c65013", "14dd6caf1527abb21f08f86c784eac40853ba93edb79552aa1e4b8aef1b61c7b"]
+markupsafe = ["00bc623926325b26bb9605ae9eae8a215691f33cae5df11ca5424f06f2d1f473", "09027a7803a62ca78792ad89403b1b7a73a01c8cb65909cd876f7fcebd79b161", "09c4b7f37d6c648cb13f9230d847adf22f8171b1ccc4d5682398e77f40309235", "1027c282dad077d0bae18be6794e6b6b8c91d58ed8a8d89a89d59693b9131db5", "24982cc2533820871eba85ba648cd53d8623687ff11cbb805be4ff7b4c971aff", "29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b", "43a55c2930bbc139570ac2452adf3d70cdbb3cfe5912c71cdce1c2c6bbd9c5d1", "46c99d2de99945ec5cb54f23c8cd5689f6d7177305ebff350a58ce5f8de1669e", "500d4957e52ddc3351cabf489e79c91c17f6e0899158447047588650b5e69183", "535f6fc4d397c1563d08b88e485c3496cf5784e927af890fb3c3aac7f933ec66", "62fe6c95e3ec8a7fad637b7f3d372c15ec1caa01ab47926cfdf7a75b40e0eac1", "6dd73240d2af64df90aa7c4e7481e23825ea70af4b4922f8ede5b9e35f78a3b1", "717ba8fe3ae9cc0006d7c451f0bb265ee07739daf76355d06366154ee68d221e", "79855e1c5b8da654cf486b830bd42c06e8780cea587384cf6545b7d9ac013a0b", "7c1699dfe0cf8ff607dbdcc1e9b9af1755371f92a68f706051cc8c37d447c905", "88e5fcfb52ee7b911e8bb6d6aa2fd21fbecc674eadd44118a9cc3863f938e735", "8defac2f2ccd6805ebf65f5eeb132adcf2ab57aa11fdf4c0dd5169a004710e7d", "98c7086708b163d425c67c7a91bad6e466bb99d797aa64f965e9d25c12111a5e", "9add70b36c5666a2ed02b43b335fe19002ee5235efd4b8a89bfcf9005bebac0d", "9bf40443012702a1d2070043cb6291650a0841ece432556f784f004937f0f32c", "ade5e387d2ad0d7ebf59146cc00c8044acbd863725f887353a10df825fc8ae21", "b00c1de48212e4cc9603895652c5c410df699856a2853135b3967591e4beebc2", "b1282f8c00509d99fef04d8ba936b156d419be841854fe901d8ae224c59f0be5", "b2051432115498d3562c084a49bba65d97cf251f5a331c64a12ee7e04dacc51b", "ba59edeaa2fc6114428f1637ffff42da1e311e29382d81b339c1817d37ec93c6", "c8716a48d94b06bb3b2524c2b77e055fb313aeb4ea620c8dd03a105574ba704f", "cd5df75523866410809ca100dc9681e301e3c27567cf498077e8551b6d20e42f", "e249096428b3ae81b08327a63a485ad0878de3fb939049038579ac0ef61e17e7"]
+marshmallow = ["0e497a6447ffaad55578138ca512752de7a48d12f444996ededc3d6bf8a09ca2", "e21a4dea20deb167c723e0ffb13f4cf33bcbbeb8a334e92406a3308cedea2826"]
+parso = ["17cc2d7a945eb42c3569d4564cdf49bde221bc2b552af3eca9c1aad517dcdd33", "2e9574cb12e7112a87253e14e2c380ce312060269d04bd018478a3c92ea9a376"]
+pexpect = ["2094eefdfcf37a1fdbfb9aa090862c1a4878e5c7e0e7e7088bdb511c558e5cd1", "9e2c1fd0e6ee3a49b28f95d4b33bc389c89b20af6a1255906e90ff1262ce62eb"]
+pickleshare = ["87683d47965c1da65cdacaf31c8441d12b8044cdec9aca500cd78fc2c683afca", "9649af414d74d4df115d5d718f82acb59c9d418196b7b4290ed47a12ce62df56"]
+prompt-toolkit = ["11adf3389a996a6d45cc277580d0d53e8a5afd281d0c9ec71b28e6f121463780", "2519ad1d8038fd5fc8e770362237ad0364d16a7650fb5724af6997ed5515e3c1", "977c6583ae813a37dc1c2e1b715892461fcbdaa57f6fc62f33a528c4886c8f55"]
+ptyprocess = ["923f299cc5ad920c68f2bc0bc98b75b9f838b93b599941a6b63ddbc2476394c0", "d7cc528d76e76342423ca640335bd3633420dc1366f258cb31d05e865ef5ca1f"]
+pygments = ["71e430bc85c88a430f000ac1d9b331d2407f681d6f6aec95e8bcfbc3df5b0127", "881c4c157e45f30af185c1ffe8d549d48ac9127433f2c380c24b84572ad66297"]
+python-dotenv = ["156f218846bd90e0d537915545cde4a987947c2cecc628b50f9955fdde72534a", "6640acd76e6cab84648e4fec16c9d19de6700971f9d91d045e7120622167bfda"]
+pyyaml = ["1adecc22f88d38052fb787d959f003811ca858b799590a5eaa70e63dca50308c", "436bc774ecf7c103814098159fbb84c2715d25980175292c648f2da143909f95", "460a5a4248763f6f37ea225d19d5c205677d8d525f6a83357ca622ed541830c2", "5a22a9c84653debfbf198d02fe592c176ea548cccce47553f35f466e15cf2fd4", "7a5d3f26b89d688db27822343dfa25c599627bc92093e788956372285c6298ad", "9372b04a02080752d9e6f990179a4ab840227c6e2ce15b95e1278456664cf2ba", "a5dcbebee834eaddf3fa7366316b880ff4062e4bcc9787b78c7fbb4a26ff2dd1", "aee5bab92a176e7cd034e57f46e9df9a9862a71f8f37cad167c6fc74c65f5b4e", "c51f642898c0bacd335fc119da60baae0824f2cde95b0330b56c0553439f0673", "c68ea4d3ba1705da1e0d85da6684ac657912679a649e8868bd850d2c299cce13", "e23d0cc5299223dcc37885dae624f382297717e459ea24053709675a976a3e19"]
+requests = ["11e007a8a2aa0323f5a921e9e6a2d7e4e67d9877e85773fba9ba6419025cbeb4", "9cf5292fcd0f598c671cfc1e0d7d1a7f13bb8085e9a590f48c010551dc6c4b31"]
+six = ["3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c", "d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"]
+traitlets = ["9c4bd2d267b7153df9152698efb1050a5d84982d3384a37b2c1f7723ba3e7835", "c6cb5e6f57c5a9bdaa40fa71ce7b4af30298fbab9ece9815b5d995ab6217c7d9"]
+urllib3 = ["b246607a25ac80bedac05c6f282e3cdaf3afb65420fd024ac94435cabe6e18d1", "dbe59173209418ae49d485b87d1681aefa36252ee85884c31346debd19463232"]
+wcwidth = ["3df37372226d6e63e1b1e1eda15c594bca98a22d33a23832a90998faa96bc65e", "f4ebe71925af7b40a864553f761ed559b43544f8f71746c2d756c7fe788ade7c"]

--- a/scripts/auth0connections/pyproject.toml
+++ b/scripts/auth0connections/pyproject.toml
@@ -1,0 +1,21 @@
+[tool.poetry]
+name = "auth0connections"
+version = "0.1.0"
+description = "Sync connections with Auth0 Management API"
+authors = ["Ravi Kotecha <ravi.kotecha@digital.justice.gov.uk>"]
+license = "MIT"
+
+[tool.poetry.dependencies]
+python = "^3.7"
+click = "^7.0"
+auth0-python = "^3.7"
+environs = "^4.1"
+jinja2 = "^2.10"
+pyyaml = "^5.1"
+
+[tool.poetry.dev-dependencies]
+ipython = "^7.5"
+
+[build-system]
+requires = ["poetry>=0.12"]
+build-backend = "poetry.masonry.api"

--- a/scripts/auth0connections/values.example.yaml
+++ b/scripts/auth0connections/values.example.yaml
@@ -1,0 +1,8 @@
+---
+nomis:
+    client_id: "your client id"
+    client_secret: "your client secret"
+    gateway_url: "base url"
+    authorize_endpoint: /auth/oauth/authorize
+    token_endpoint: /auth/oauth/token
+    user_endpoint: /auth/api/user/me


### PR DESCRIPTION
## What

Document how to create additional auth0 connections (without using `terraform`).
This also adds a script to run, which will create the defined connections
instead of documenting how to do this manually in the auth0 console.


related config change: https://github.com/ministryofjustice/analytics-platform-config/pull/143

cc @sh31 because I know you're working on something similar, maybe this can be removed if your way works for creating connections