### PR TITLE
Js-yaml prior to 3.13.1 are vulnerable to Code Injection.

### DIFF
--- a/scripts/invariant_checks/package-lock.json
+++ b/scripts/invariant_checks/package-lock.json
@@ -502,7 +502,7 @@
         "imurmurhash": "^0.1.4",
         "inquirer": "^6.1.0",
         "is-resolvable": "^1.1.0",
-        "js-yaml": "^3.12.0",
+        "js-yaml": "^3.13.1",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.3.0",
         "lodash": "^4.17.5",
@@ -1298,9 +1298,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
-      "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -1364,7 +1364,7 @@
       "integrity": "sha512-H4Phnw7zWV3nYzvMqc84DDexr1Da8sRokPWoDLxLuVJSTPnqVuXpAPAWPqNcZzZdm4kWddTfKTjpg8iOYHiDDQ==",
       "requires": {
         "fluent-openapi": "0.1.1",
-        "js-yaml": "^3.10.0",
+        "js-yaml": "^3.13.1",
         "openid-client": "^2.0.0",
         "request": "^2.83.0"
       }


### PR DESCRIPTION
WS-2019-0063 More information
high severity
Vulnerable versions: < 3.13.1
Patched version: 3.13.1
Js-yaml prior to 3.13.1 are vulnerable to Code Injection. The load() function may execute arbitrary code injected through a malicious YAML file.