### PR TITLE
Auth0 connections: Fetch user profile script will now store access token in profile

### DIFF
--- a/scripts/auth0connections/connections/nomis/fetchUserProfile.js
+++ b/scripts/auth0connections/connections/nomis/fetchUserProfile.js
@@ -24,9 +24,12 @@ function(accessToken, ctx, cb) {
       var profile = {
         user_id: parsedBody.staffId,
         nickname: parsedBody.name,
+        name: parsedBody.name,
+        email: parsedBody.username + "+" + parsedBody.activeCaseLoadId + "@nomis",
         username: parsedBody.username,
         blocked: !parsedBody.active,
-        activeCaseLoadId: parsedBody.activeCaseLoadId
+        activeCaseLoadId: parsedBody.activeCaseLoadId,
+        _nomisAccessToken: accessToken
       };
       cb(null, profile);
     }


### PR DESCRIPTION
## What

This stores the user accessToken in the user profile. This is to allow apps to make calls to the nomis api gateway using the auth token received as part of the oauth2 login flow

https://trello.com/c/ZZ4Cs0tI/250-nomis-login-for-sdt