### PR TITLE
Params perms requires account and region

### DIFF
--- a/infra/terraform/modules/user_get_parameter/iam.tf
+++ b/infra/terraform/modules/user_get_parameter/iam.tf
@@ -20,7 +20,7 @@ data "aws_iam_policy_document" "parameter_readonly_document" {
     effect = "Allow"
 
     resources = [
-      "arn:aws:ssm:::parameter/${var.env}/webapp/*",
+      "arn:aws:ssm:*:*:parameter/${var.env}/webapp/*",
     ]
   }
 


### PR DESCRIPTION
Adds wildcard perms in for region and account as those are both needed for the Parameters

