### PR TITLE
Allow Control Panel to set public access block

### DIFF
--- a/infra/terraform/modules/control_panel_api/role.tf
+++ b/infra/terraform/modules/control_panel_api/role.tf
@@ -39,6 +39,7 @@ resource "aws_iam_policy" "control_panel_api" {
       "Action": [
         "s3:CreateBucket",
         "s3:PutBucketLogging",
+        "s3:PutBucketPublicAccessBlock",
         "s3:PutBucketTagging",
         "s3:PutEncryptionConfiguration"
       ],


### PR DESCRIPTION
When creating S3 Buckets in Control Panel, it needs to set public access block by default
