### PR TITLE
CP can delete apps' roles

### DIFF
--- a/infra/terraform/modules/control_panel_api/role.tf
+++ b/infra/terraform/modules/control_panel_api/role.tf
@@ -106,6 +106,7 @@ resource "aws_iam_policy" "control_panel_api" {
       "Sid": "CanDeleteRoles",
       "Effect": "Allow",
       "Action": [
+        "iam:GetRole",
         "iam:DeleteRole",
         "iam:ListAttachedRolePolicies",
         "iam:ListRolePolicies",


### PR DESCRIPTION
While deleting an App from CP I got the following permission error:

> An error occurred (AccessDenied) when calling the GetRole operation: User: arn:aws:sts::XXX:assumed-role/alpha_control_panel_api/XXX-alpha_control_panel_api is not authorized to perform: iam:GetRole on resource: role alpha_app_XXX

Fixes Sentry error: https://sentry.service.dsd.io/mojds/control-panel-api/issues/38606/

Ticket: https://trello.com/c/ymJUXt06