### PR TITLE
Terraform import of SoftNAS volume 6 and 7

### DIFF
--- a/infra/terraform/modules/user_nfs_softnas/ebs.tf
+++ b/infra/terraform/modules/user_nfs_softnas/ebs.tf
@@ -140,7 +140,7 @@ resource "aws_volume_attachment" "softnas_vol5" {
 }
 
 resource "aws_volume_attachment" "softnas_vol6" {
-  device_name = "/dev/xvdk"
+  device_name = "/dev/sdk"
   instance_id = "${element(aws_instance.softnas.*.id, count.index)}"
   volume_id   = "${element(aws_ebs_volume.softnas_vol6.*.id, count.index)}"
 

--- a/infra/terraform/modules/user_nfs_softnas/ebs.tf
+++ b/infra/terraform/modules/user_nfs_softnas/ebs.tf
@@ -99,6 +99,21 @@ resource "aws_ebs_volume" "softnas_vol6" {
   ), var.tags)}"
 }
 
+# Created EBS volume only for `softnas-1` in AWS Console - that's why there
+# is no loop/count in this resource
+resource "aws_ebs_volume" "softnas_1_vol7" {
+  availability_zone = "${aws_instance.softnas.1.availability_zone}"
+  type              = "gp2"
+  size              = "2048"
+  encrypted         = true
+
+  tags = "${merge(map(
+    "Name", "${var.env}-${var.name_identifier}-1-vol7",
+    "env", "${var.env}",
+    "is-production", "${var.is_production}",
+  ), var.tags)}"
+}
+
 resource "aws_volume_attachment" "softnas_vol1" {
   device_name = "/dev/sdf"
   volume_id   = "${element(aws_ebs_volume.softnas_vol1.*.id, count.index)}"
@@ -145,4 +160,12 @@ resource "aws_volume_attachment" "softnas_vol6" {
   volume_id   = "${element(aws_ebs_volume.softnas_vol6.*.id, count.index)}"
 
   count = "${var.num_instances}"
+}
+
+# Created EBS volume only for `softnas-1` in AWS Console - that's why there
+# is no loop/count in this resource
+resource "aws_volume_attachment" "softnas_1_vol7" {
+  device_name = "/dev/sdl"
+  instance_id = "${aws_instance.softnas.1.id}"
+  volume_id   = "${aws_ebs_volume.softnas_1_vol7.id}"
 }


### PR DESCRIPTION
Volume 6 was already in Terraform but one volume attachment had the "wrong"/different device name.

Volume 7 was previously created manually in AWS Console but now it's in Terraform. **NOTE**: there is only one volume for `softnas-1` as `softnas-0` doesn't seem to be used and Serj thought it was wasteful to create a 2TB volume which is not actually used - that's why these Terraform resources don't have a loop (`count`) unlike the others.