### PR TITLE
Upgraded Terraform aws provider to version ~> 2.45

### DIFF
--- a/infra/terraform/platform/main.tf
+++ b/infra/terraform/platform/main.tf
@@ -9,7 +9,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.region}"
-  version = "~> 1.60"
+  version = "~> 2.45"
 }
 
 module "data_buckets" {

--- a/infra/terraform/platform/main.tf
+++ b/infra/terraform/platform/main.tf
@@ -9,7 +9,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.region}"
-  version = "~> 1.50"
+  version = "~> 1.60"
 }
 
 module "data_buckets" {


### PR DESCRIPTION
From version `~> 1.50` to version `~> 2.45`.

I upgrade this as support for tags on `aws_dlm_lifecycle_policy ` ([introduced in version `2.37.0`](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md#2370-november-18-2019))

`terraform plan` doesn't show any warnings or problems so far.


Part of ticket: https://trello.com/c/4YSbvgFu