### PR TITLE
ebs_snapshots: Add tags to DLM Policy resources

### DIFF
--- a/infra/terraform/modules/ebs_snapshots/README.md
+++ b/infra/terraform/modules/ebs_snapshots/README.md
@@ -25,9 +25,11 @@ Parameters
 | ------------------------------------ | ------------ | ----------------------------------------- |
 | `name`                (**Required**) | `string`     | The common name given to resources        |
 | `target_tags`         (**Required**) | `map`        | The DLM will take a snapshot of all EBS volumes with any of these target tags |
+| `env`                 (**Required**) | `string`     | Environment name. It will be used as DLM `env` tag value |
+| `is_production`       (**Required**) | `string`     | Whether is a production environment. Can be `false` or `true`. It will be used as DLM `is-production` tag value |
 | `schedule_interval`                  | `int`        | The interval at which the dlm will run (**default `12`**) |
 | `schedule_interval_unit`             | `string`     | The unit of time that applies to the schedule interval (**default `HOURS`**) |
 | `schedule_time`                      | `string`     | The time of day at which the dlm will run (**default `00:45`**) |
-| `retain_count`                    | `int`        | The number of snapshots to retain (**default `28`**) |
+| `retain_count`                       | `int`        | The number of snapshots to retain (**default `28`**) |
 | `schedule_copy_tags`                 | `boolean`    | Whether or not to copy tags from the targeted volume to the resulting snapshot (**default `true`**)|
-| `lifecycle_enabled`                  | `string`     | Whether or not to enable the DLM, can be `"ENABLED"` or `"DISABLED"` (**default `"ENABLED"`**) |
+| `lifecycle_enabled`                  | `string`     | Whether or not to enable the DLM. It can be `"ENABLED"` or `"DISABLED"` (**default `"ENABLED"`**) |

--- a/infra/terraform/modules/ebs_snapshots/dlm.tf
+++ b/infra/terraform/modules/ebs_snapshots/dlm.tf
@@ -1,5 +1,5 @@
 resource "aws_dlm_lifecycle_policy" "dlm_lifecycle" {
-  description = "DLM Lifecycle Policy to take periodic EBS snapshots"
+  description = "DLM Lifecycle Policy to take periodic EBS snapshots - ${var.env}"
   state       = "${var.lifecycle_state}"
 
   execution_role_arn = "${aws_iam_role.dlm_role.arn}"
@@ -27,4 +27,10 @@ resource "aws_dlm_lifecycle_policy" "dlm_lifecycle" {
       }
     }
   }
+
+  tags = "${merge(map(
+    "Name", "${var.name}",
+    "env", "${var.env}",
+    "is-production", "${var.is_production ? "true" : "false"}",
+  ), var.tags)}"
 }

--- a/infra/terraform/modules/ebs_snapshots/iam.tf
+++ b/infra/terraform/modules/ebs_snapshots/iam.tf
@@ -7,6 +7,11 @@ resource "aws_iam_role" "dlm_role" {
   name                  = "${var.name}-role"
   assume_role_policy    = "${data.aws_iam_policy_document.assume.json}"
   force_detach_policies = true
+
+  tags = "${merge(map(
+    "env", "${var.env}",
+    "is-production", "${var.is_production ? "true" : "false"}",
+  ), var.tags)}"
 }
 
 resource "aws_iam_policy_attachment" "dlm_policy_policy_attachment" {

--- a/infra/terraform/modules/ebs_snapshots/variables.tf
+++ b/infra/terraform/modules/ebs_snapshots/variables.tf
@@ -1,4 +1,5 @@
 variable "name" {
+  type        = "string"
   description = "The common name given to resources"
 }
 
@@ -8,6 +9,7 @@ variable "target_tags" {
 }
 
 variable "schedule_time" {
+  type        = "string"
   default     = "00:45"
   description = "The time of day at which the DLM will run"
 }
@@ -18,6 +20,7 @@ variable "schedule_interval" {
 }
 
 variable "schedule_interval_unit" {
+  type        = "string"
   default     = "HOURS"
   description = "The unit of time that applies to the schedule interval"
 }
@@ -33,6 +36,27 @@ variable "schedule_copy_tags" {
 }
 
 variable "lifecycle_state" {
+  type        = "string"
   default     = "ENABLED"
   description = "Whether or not to enable the DLM"
+}
+
+variable "env" {
+  type        = "string"
+  description = "environment name (env tag of DLM)"
+}
+
+variable "is_production" {
+  description = "whether is a production environment (is-production tag of DLM)"
+}
+
+variable "tags" {
+  type        = "map"
+  description = "Tags for DLM"
+
+  default = {
+    business-unit = "Platforms"
+    application   = "analytical-platform"
+    owner         = "analytical-platform:analytics-platform-tech@digital.justice.gov.uk"
+  }
 }

--- a/infra/terraform/platform/main.tf
+++ b/infra/terraform/platform/main.tf
@@ -39,7 +39,9 @@ module "user_nfs_softnas" {
 module "ebs_snapshots" {
   source = "../modules/ebs_snapshots"
 
-  name = "${terraform.workspace}-dlm"
+  name          = "${terraform.workspace}-dlm"
+  env           = "${terraform.workspace}"
+  is_production = "${var.is_production}"
 
   target_tags = {
     env = "${terraform.workspace}"


### PR DESCRIPTION
This is for consistency and it may help future team members to
determine which environment they're snapshotting, if they're used in
production, etc...

Also added `type` to variables (but interestingly Terraform doesn't have a `boolean` type 🤷‍♂ )

**NOTE**: `aws_dlm_lifecycle_policy`'s support for tags was added in
`aws` provider version `2.37.0+`:
https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md#2370-november-18-2019

Part of ticket: https://trello.com/c/4YSbvgFu