### PR TITLE
Added cloudwatch_alerts module to monitor SoftNAS

### DIFF
--- a/infra/terraform/modules/cloudwatch_alerts/README.md
+++ b/infra/terraform/modules/cloudwatch_alerts/README.md
@@ -1,0 +1,38 @@
+# CloudWatch Alerts
+
+##### Terraform module to enable CloudWatch alerts
+
+Sends alerts when CPU usage goes above ${cpu_threshold} percent.
+
+Usage
+-----
+
+Create the CloudWatch alerts for the specified EC2 instances
+
+```hcl-terraform
+module "softnas_monitoring" {
+  source = "../modules/cloudwatch_alerts"
+
+  name               = "${terraform.workspace}-softnas-alerts"
+  ec2_instance_ids   = "${module.user_nfs_softnas.ec2_instance_ids}"
+  ec2_instance_names = "${module.user_nfs_softnas.ec2_instance_names}"
+  cpu_threshold      = 80
+  email         = "analytics-platform-tech@digital.justice.gov.uk"
+
+  component     = "SoftNAS"
+  env           = "${terraform.workspace}"
+  is_production = "${var.is_production}"
+}
+```
+
+Parameters
+-----------
+| Name                                 | Type     | Description                               |
+| ------------------------------------ | -------- | ----------------------------------------- |
+| `name`                (**Required**) | `string` | Name of the resources |
+| `ec2_instance_names`  (**Required**) | `list`   | Names of the EC2 instances to monitor |
+| `ec2_instance_ids`    (**Required**) | `list`   | IDs of the EC2 instances to monitor |
+| `env`                 (**Required**) | `string` | Environment name. It will be used as value for the `env` tag |
+| `is_production`       (**Required**) | `string` | Whether is a production environment. Can be `false` or `true`. It will be used as value for the `is-production` tag value |
+| `email`                              | `string` | email address where alerts are sent to |
+| `cpu_threshold`                      | `number` | CPU usage threashold (percentage) which triggers the alert (**default `80`**) |

--- a/infra/terraform/modules/cloudwatch_alerts/cloudwatch.tf
+++ b/infra/terraform/modules/cloudwatch_alerts/cloudwatch.tf
@@ -1,0 +1,28 @@
+resource "aws_cloudwatch_metric_alarm" "cpu_threshold" {
+  count             = "${length(var.ec2_instance_names)}"
+  alarm_name        = "${var.name}_${element(var.ec2_instance_names, count.index)}-cpu-alarm"
+  alarm_description = "This metric monitors EC2 CPU utilisation"
+
+  dimensions = {
+    InstanceId = "${element(var.ec2_instance_ids, count.index)}"
+  }
+
+  namespace           = "AWS/EC2"
+  metric_name         = "CPUUtilization"
+  statistic           = "Maximum"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  threshold           = "${var.cpu_threshold}"
+  period              = "300"                           # 5 minutes
+  evaluation_periods  = "3"
+  datapoints_to_alarm = "2"
+  treat_missing_data  = "breaching"
+
+  actions_enabled = "true"
+  alarm_actions   = ["${ aws_cloudformation_stack.notifications.outputs["ARN"] }"]
+
+  tags = "${merge(map(
+    "component", "${var.component}",
+    "env", "${var.env}",
+    "is-production", "${var.is_production ? "true" : "false"}",
+  ), var.tags)}"
+}

--- a/infra/terraform/modules/cloudwatch_alerts/sns.tf
+++ b/infra/terraform/modules/cloudwatch_alerts/sns.tf
@@ -1,0 +1,20 @@
+data "template_file" "cloudformation_sns_alarms_notifications" {
+  vars {
+    display_name = "${var.name}-notifications"
+    subscription = "${var.email}"
+  }
+
+  template = "${file("${path.module}/template-email-sns-stack.json.tpl")}"
+}
+
+resource "aws_cloudformation_stack" "notifications" {
+  name          = "${var.name}-notifications"
+  template_body = "${data.template_file.cloudformation_sns_alarms_notifications.rendered}"
+
+  tags = "${merge(map(
+    "Name", "${var.name}-notifications",
+    "component", "${var.component}",
+    "env", "${var.env}",
+    "is-production", "${var.is_production ? "true" : "false"}",
+  ), var.tags)}"
+}

--- a/infra/terraform/modules/cloudwatch_alerts/template-email-sns-stack.json.tpl
+++ b/infra/terraform/modules/cloudwatch_alerts/template-email-sns-stack.json.tpl
@@ -1,0 +1,25 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Resources": {
+    "EmailSNSTopic": {
+      "Type": "AWS::SNS::Topic",
+      "Properties": {
+        "DisplayName": "${display_name}",
+        "Subscription": [
+          {
+            "Endpoint": "${subscription}",
+            "Protocol": "email"
+          }
+        ]
+      }
+    }
+  },
+  "Outputs": {
+    "ARN": {
+      "Description": "Email SNS Topic ARN",
+      "Value": {
+        "Ref": "EmailSNSTopic"
+      }
+    }
+  }
+}

--- a/infra/terraform/modules/cloudwatch_alerts/variables.tf
+++ b/infra/terraform/modules/cloudwatch_alerts/variables.tf
@@ -1,0 +1,49 @@
+variable "name" {
+  type        = "string"
+  description = "The common name given to resources"
+}
+
+variable "ec2_instance_names" {
+  type        = "list"
+  description = "Names of the EC2 instances to monitor"
+}
+
+variable "ec2_instance_ids" {
+  type        = "list"
+  description = "IDs of the EC2 instances to monitor"
+}
+
+variable "cpu_threshold" {
+  default     = 80
+  description = "CPU usage threashold (percentage) which triggers the alert (**default `80`**)"
+}
+
+variable "email" {
+  type        = "string"
+  description = "email address where alerts are sent to"
+}
+
+variable "component" {
+  type        = "string"
+  description = "component which is monitored, e.g. SoftNAS"
+}
+
+variable "env" {
+  type        = "string"
+  description = "environment name (env tag of DLM)"
+}
+
+variable "is_production" {
+  description = "whether is a production environment (is-production tag of DLM)"
+}
+
+variable "tags" {
+  type        = "map"
+  description = "Tags for DLM"
+
+  default = {
+    business-unit = "Platforms"
+    application   = "analytical-platform"
+    owner         = "analytical-platform:analytics-platform-tech@digital.justice.gov.uk"
+  }
+}

--- a/infra/terraform/modules/user_nfs_softnas/outputs.tf
+++ b/infra/terraform/modules/user_nfs_softnas/outputs.tf
@@ -1,0 +1,7 @@
+output "ec2_instance_names" {
+  value = "${aws_instance.softnas.*.tags.Name}"
+}
+
+output "ec2_instance_ids" {
+  value = "${aws_instance.softnas.*.id}"
+}

--- a/infra/terraform/platform/main.tf
+++ b/infra/terraform/platform/main.tf
@@ -48,6 +48,20 @@ module "ebs_snapshots" {
   }
 }
 
+module "softnas_monitoring" {
+  source = "../modules/cloudwatch_alerts"
+
+  name               = "${terraform.workspace}-softnas-alerts"
+  ec2_instance_ids   = "${module.user_nfs_softnas.ec2_instance_ids}"
+  ec2_instance_names = "${module.user_nfs_softnas.ec2_instance_names}"
+  cpu_threshold      = 80
+  email              = "analytics-platform-tech@digital.justice.gov.uk"
+
+  component     = "SoftNAS"
+  env           = "${terraform.workspace}"
+  is_production = "${var.is_production}"
+}
+
 module "concourse_parameter_user" {
   source = "../modules/user_get_parameter"
 


### PR DESCRIPTION
Send email if CPU spikes over 80% for 2 five minutes periods in the last
15 minutes.

Unfortunately the `aws_sns_topic_subscription` Terraform resource
doesn't support the `email` protocol:

> Unsupported protocols include the following:
> - email -- delivery of message via SMTP
> - email-json -- delivery of JSON-encoded message via SMTP
>
> These are unsupported because the endpoint needs to be authorized and
> does not generate an ARN until the target email address has been
> validated. This breaks the Terraform model and as a result are not
> currently supported.

Apparently this is because of the manual click to subscribe required.

See: https://www.terraform.io/docs/providers/aws/r/sns_topic_subscription.html

For this reason the module creates a CloudFormation stack which creates
SNS topic. The CloudWatch alarm then uses this SNS topic created by
this stack to send the email notifications.

Ticket: https://trello.com/c/wI7T79OV