### PR TITLE
Change kops.yaml template in kops_spec terraform module to use oidc_issuer_url for oidcUsernamePrefix parameter

### DIFF
--- a/infra/terraform/modules/kops_spec/templates/kops.yaml.tmpl
+++ b/infra/terraform/modules/kops_spec/templates/kops.yaml.tmpl
@@ -49,7 +49,7 @@ ${etcd_events_members}
     oidcGroupsClaim: https://api.${cluster_dns_name}/claims/groups
     oidcIssuerURL: ${oidc_issuer_url}
     oidcUsernameClaim: nickname
-    oidcUsernamePrefix: ${oidc_provider_url}#
+    oidcUsernamePrefix: ${oidc_issuer_url}#
     runtimeConfig:
       batch/v2alpha1: "true"
   kubelet:


### PR DESCRIPTION
Change kops.yaml template in kops_spec terraform module to use the oidc_issuer_url variable for the oidcUsernamePrefix parameter (instead of oidc_provider_url )

## What

The kops.yaml.tmpl template in the kops_spec terraform module currently uses the oidc_provider_url variable to set the oidcUsernamePrefix parameter.

As we do not pass the oidc_provider_url variable into the kops.yaml.tmpl template the terraform plan/apply fails with following error.

* module.kops_spec.data.template_file.kops: 1 error occurred:
	* module.kops_spec.data.template_file.kops: data.template_file.kops: failed to render : <template_file>:52,27-44: Unknown variable; There is no variable named "oidc_provider_url


To fix this we can use the existing variable oidc_issuer_url for the oidcUsernamePrefix parameter instead.


## How to review

This change results in a successful terraform plan (with no outstanding changes).

------------------------------------------------------------------------

No changes. Infrastructure is up-to-date.

This means that Terraform did not detect any differences between your
configuration and real physical resources that exist. As a result, no
actions need to be performed.


