### PR TITLE
Add Cloudwatch alert for low CPU and change high alert threshold to 70% for SoftNAS EC2

### DIFF
--- a/infra/terraform/modules/cloudwatch_alerts/cloudwatch.tf
+++ b/infra/terraform/modules/cloudwatch_alerts/cloudwatch.tf
@@ -37,7 +37,7 @@ resource "aws_cloudwatch_metric_alarm" "cpu_low_threshold" {
   statistic           = "Maximum"
   comparison_operator = "LessThanThreshold"
   threshold           = "${var.cpu_low_threshold}"
-  period              = "300"                           # 5 minutes
+  period              = "300"                      # 5 minutes
   evaluation_periods  = "3"
   datapoints_to_alarm = "2"
   treat_missing_data  = "breaching"

--- a/infra/terraform/modules/cloudwatch_alerts/cloudwatch.tf
+++ b/infra/terraform/modules/cloudwatch_alerts/cloudwatch.tf
@@ -22,3 +22,28 @@ resource "aws_cloudwatch_metric_alarm" "cpu_threshold" {
 
   tags = "${var.tags}"
 }
+
+resource "aws_cloudwatch_metric_alarm" "cpu_low_threshold" {
+  count             = "${length(var.ec2_instance_names)}"
+  alarm_name        = "${var.name}_${element(var.ec2_instance_names, count.index)}-cpu-low-alarm"
+  alarm_description = "This metric monitors low EC2 CPU utilisation"
+
+  dimensions = {
+    InstanceId = "${element(var.ec2_instance_ids, count.index)}"
+  }
+
+  namespace           = "AWS/EC2"
+  metric_name         = "CPUUtilization"
+  statistic           = "Maximum"
+  comparison_operator = "LessThanThreshold"
+  threshold           = "${var.cpu_low_threshold}"
+  period              = "300"                           # 5 minutes
+  evaluation_periods  = "3"
+  datapoints_to_alarm = "2"
+  treat_missing_data  = "breaching"
+
+  actions_enabled = "true"
+  alarm_actions   = ["${ aws_cloudformation_stack.notifications.outputs["ARN"] }"]
+
+  tags = "${var.tags}"
+}

--- a/infra/terraform/modules/cloudwatch_alerts/variables.tf
+++ b/infra/terraform/modules/cloudwatch_alerts/variables.tf
@@ -14,8 +14,13 @@ variable "ec2_instance_ids" {
 }
 
 variable "cpu_threshold" {
-  default     = 80
-  description = "CPU usage threashold (percentage) which triggers the alert (**default `80`**)"
+  default     = 75
+  description = "High CPU usage threshold (percentage) which triggers the alert (**default `75`**)"
+}
+
+variable "cpu_low_threshold" {
+  default     = 5
+  description = "Low CPU usage threshold (percentage) which triggers the alert (**default `5`**)"
 }
 
 variable "email" {

--- a/infra/terraform/modules/cloudwatch_alerts/variables.tf
+++ b/infra/terraform/modules/cloudwatch_alerts/variables.tf
@@ -14,8 +14,8 @@ variable "ec2_instance_ids" {
 }
 
 variable "cpu_threshold" {
-  default     = 75
-  description = "High CPU usage threshold (percentage) which triggers the alert (**default `75`**)"
+  default     = 70
+  description = "High CPU usage threshold (percentage) which triggers the alert (**default `70`**)"
 }
 
 variable "cpu_low_threshold" {

--- a/infra/terraform/modules/user_nfs_softnas/ec2.tf
+++ b/infra/terraform/modules/user_nfs_softnas/ec2.tf
@@ -92,6 +92,7 @@ resource "aws_instance" "softnas" {
   instance_type        = "${var.instance_type}"
   key_name             = "${aws_key_pair.softnas.key_name}"
   iam_instance_profile = "${aws_iam_instance_profile.softnas.name}"
+  monitoring           = "${var.monitoring}"
 
   count = "${var.num_instances}"
 

--- a/infra/terraform/modules/user_nfs_softnas/inputs.tf
+++ b/infra/terraform/modules/user_nfs_softnas/inputs.tf
@@ -52,3 +52,8 @@ variable "tags" {
   type        = "map"
   description = "Tags to attach to resources"
 }
+
+variable "monitoring" {
+  description = "If true, the launched EC2 instance will have detailed monitoring enabled"
+  default = true
+}

--- a/infra/terraform/modules/user_nfs_softnas/inputs.tf
+++ b/infra/terraform/modules/user_nfs_softnas/inputs.tf
@@ -55,5 +55,5 @@ variable "tags" {
 
 variable "monitoring" {
   description = "If true, the launched EC2 instance will have detailed monitoring enabled"
-  default = true
+  default     = true
 }

--- a/infra/terraform/platform/main.tf
+++ b/infra/terraform/platform/main.tf
@@ -59,7 +59,7 @@ module "softnas_monitoring" {
   name               = "${terraform.workspace}-softnas-alerts"
   ec2_instance_ids   = "${module.user_nfs_softnas.ec2_instance_ids}"
   ec2_instance_names = "${module.user_nfs_softnas.ec2_instance_names}"
-  cpu_threshold      = 75
+  cpu_threshold      = 70
   cpu_low_threshold  = 5
   email              = "analytics-platform-tech@digital.justice.gov.uk"
 

--- a/infra/terraform/platform/main.tf
+++ b/infra/terraform/platform/main.tf
@@ -59,7 +59,8 @@ module "softnas_monitoring" {
   name               = "${terraform.workspace}-softnas-alerts"
   ec2_instance_ids   = "${module.user_nfs_softnas.ec2_instance_ids}"
   ec2_instance_names = "${module.user_nfs_softnas.ec2_instance_names}"
-  cpu_threshold      = 80
+  cpu_threshold      = 75
+  cpu_low_threshold  = 5
   email              = "analytics-platform-tech@digital.justice.gov.uk"
 
   tags = "${merge(map(


### PR DESCRIPTION
1. Add a new Cloudwatch alert for Max CPU usage less than 5% for SoftNAS EC2 instances

https://trello.com/c/OBbuQMgu/546-add-softnas-alert-for-5-cpu

2. Change high CPU threshold on Cloudwatch alert from 80% to 70% for SoftNAS EC2 instances
https://trello.com/c/zxqpfTKQ/541-adjust-cloudwatch-alert-values

3. Enabled detailed monitoring on SoftNAS EC2 instances 
