### PR TITLE
git-crypt rotate doc tweaks following usage

### DIFF
--- a/git-crypt/README.md
+++ b/git-crypt/README.md
@@ -163,16 +163,22 @@ Having deleted old users in the previous section, you must now also create a fre
 
        git checkout -b rotate-git-crypt-root-key
 
-4. Rotate the root key by running `rotate-gpg-keys.sh`:
+4. If you've not got a clone of this repo you could just download the script you need:
+
+       wget https://raw.githubusercontent.com/ministryofjustice/analytics-platform-ops/master/git-crypt/rotate-gpg-keys.sh
+       chmod +x rotate-gpg-keys.sh
+
+5. Rotate the root key by running `rotate-gpg-keys.sh`:
 
        ~/ap/analytics-platform-ops/git-crypt/rotate-gpg-keys.sh
 
-   The script will create a temp directory in `/tmp/`, re-initialise .git-crypt with the new root key, re-encrypt the files with the new master key and refresh the user .gpg files with the new root key.
-5. Push the changes to the remote:
+   For the git repo in the current directory, this script will re-initialize git-crypt with a new secret and re-add all the gpg keys. It does the work in a temporary directory, pulling the changes into the current directory at the end - so if the script fails half way through, the current directory is left unchanged, and the script can simply be rerun.
+
+6. Push the changes to the remote:
 
        git push -u origin rotate-git-crypt-root-key
 
-6. Create a PR as normal, with suggested comment:
+7. Create a PR as normal, with suggested comment:
 
        Rotated the git crypt root key by following the standard process: https://github.com/ministryofjustice/analytics-platform-ops/tree/master/git-crypt#rotate-the-root-key
 
@@ -191,13 +197,13 @@ Having deleted old users in the previous section, you must now also create a fre
 
    In this PR, every encrypted file is touched.
 
-7. Just check you can still unlock it using your GPG key:
+8. Just check you can still unlock it using your GPG key:
 
        git clone git@github.com:ministryofjustice/analytics-platform-config /tmp/myrepo
        cd /tmp/myrepo
        git crypt unlock
 
-8. When merged, warn other devs to reclone the repo, or they'll just get errors about git-crypt / smudge. e.g.:
+9. When merged, warn other devs to reclone the repo, or they'll just get errors about git-crypt / smudge. e.g.:
 
        mv analytics-platform-config analytics-platform-config.bak
        git clone git@github.com:ministryofjustice/analytics-platform-config

--- a/git-crypt/rotate-gpg-keys.sh
+++ b/git-crypt/rotate-gpg-keys.sh
@@ -1,12 +1,19 @@
 #!/bin/bash
 #
+# For the git repo in the current directory, this script will re-initialize
+# git-crypt with a new secret and re-add all the gpg keys.
 #
-# It will re-initialize git-crypt for the repository and re-add all keys except
-# the one requested for removal.
+# Purpose: by running this script, users who used to have their GPG keys in this
+# git-crypt'd repo will not be able to view future changes.
 #
-# Note: You still need to change all your secrets to fully protect yourself.
-# Removing a user will prevent them from reading future changes but they will
-# still have a copy of the data up to the point of their removal.
+# Notes:
+# 1. Before running this you should have already removed GPG keys of old users.
+# 2. Old users may still have a clone, if not the old root key to this repo,
+#    giving them access the files contained up until this rotation. So those
+#    secrets within the files will all need rotating as well.
+# 3. It does the work in a temporary directory, pulling the changes into the
+#    current directory at the end - so if the script fails half way through, the
+#    current directory is left unchanged, and the script can simply be rerun.
 #
 # Based on https://github.com/AGWA/git-crypt/issues/47#issuecomment-212734882
 #
@@ -17,7 +24,7 @@ TMPDIR=`mktemp -d`
 CURRENT_DIR=`git rev-parse --show-toplevel`
 BASENAME=$(basename `pwd`)
 
-# Unlock the directory, we need to copy encrypted versions of the files
+# Unlock the directory - we need to copy encrypted versions of the files
 git crypt unlock
 
 # Work on copy.


### PR DESCRIPTION
* it's convenient for data engineers to be able to download the script without cloning the repo
* improved description of what the rotate script does