### PR TITLE
Add Cloudwatch alerts for CPU usage of Kubernetes master instances

### DIFF
--- a/infra/terraform/modules/asg_cloudwatch_alerts/README.md
+++ b/infra/terraform/modules/asg_cloudwatch_alerts/README.md
@@ -28,6 +28,6 @@ Parameters
 | Name                                 | Type     | Description                               |
 | ------------------------------------ | -------- | ----------------------------------------- |
 | `name`                (**Required**) | `string` | Name of the resources |
-| `asg_name`            (**Required**) | `string` | Names of the ELB to monitor |
+| `asg_names`            (**Required**) | `string` | Names of the ELB to monitor |
 | `alarm_actions`       (**Required**) | `list`   | List of ARNS of resources for alerts to be sent to |
 | `tags`                (**Required**) | `map`    | Tags to attach to resources |

--- a/infra/terraform/modules/asg_cloudwatch_alerts/README.md
+++ b/infra/terraform/modules/asg_cloudwatch_alerts/README.md
@@ -1,0 +1,33 @@
+# CloudWatch Alerts
+
+##### Terraform module to enable CloudWatch alerts for an Auto Scaling Group
+
+Sends alerts when CPU usage goes above ${cpu_threshold} percent.
+
+Usage
+-----
+
+Create the CloudWatch alerts for the specified ELB
+
+```hcl-terraform
+module "kubenetes_master_monitoring" {
+  source = "../modules/asg_cloudwatch_alerts"
+
+  name               = "${terraform.workspace}-kubenetes-master-alerts"
+  asg_names          = "${var.kubenetes_master_asg_names}"
+  alarm_actions      = ["${module.softnas_monitoring.stack_notifications_arn}"]
+
+  tags = "${merge(map(
+    "component", "Kubenetes",
+  ), var.tags)}"
+}
+```
+
+Parameters
+-----------
+| Name                                 | Type     | Description                               |
+| ------------------------------------ | -------- | ----------------------------------------- |
+| `name`                (**Required**) | `string` | Name of the resources |
+| `asg_name`            (**Required**) | `string` | Names of the ELB to monitor |
+| `alarm_actions`       (**Required**) | `list`   | List of ARNS of resources for alerts to be sent to |
+| `tags`                (**Required**) | `map`    | Tags to attach to resources |

--- a/infra/terraform/modules/asg_cloudwatch_alerts/cloudwatch.tf
+++ b/infra/terraform/modules/asg_cloudwatch_alerts/cloudwatch.tf
@@ -1,0 +1,24 @@
+resource "aws_cloudwatch_metric_alarm" "cpu_usage" {
+  count             = "${length(var.asg_names)}"
+  alarm_name        = "${var.name}_${element(var.asg_names, count.index)}-cpu-usage-alarm"
+  alarm_description = "This metric monitors the CPU Usage of the EC2 instances in an Autoscaling group."
+
+  dimensions = {
+    AutoScalingGroupName = "${element(var.asg_names, count.index)}"
+  }
+
+  namespace           = "AWS/EC2"
+  metric_name         = "CPUUtilization"
+  statistic           = "Average"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  threshold           = "${var.cpu_threshold}"
+  period              = "${var.period}"
+  evaluation_periods  = "${var.evaluation_periods}"
+  datapoints_to_alarm = "${var.datapoints_to_alarm}"
+  treat_missing_data  = "breaching"
+
+  actions_enabled = "true"
+  alarm_actions   = ["${var.alarm_actions}"]
+
+  tags = "${var.tags}"
+}

--- a/infra/terraform/modules/asg_cloudwatch_alerts/variables.tf
+++ b/infra/terraform/modules/asg_cloudwatch_alerts/variables.tf
@@ -1,0 +1,40 @@
+variable "name" {
+  type        = "string"
+  description = "The common name given to resources"
+}
+
+variable "asg_names" {
+  type        = "list"
+  description = "Names of the Auto Scaling Groups to monitor"
+}
+
+variable "cpu_threshold" {
+  default     = 70
+  description = "High CPU usage threshold (percentage) which triggers the alert (**default `70`**)"
+}
+
+variable "period" {
+  description = "The period in seconds over which the specified statistic is applied."
+  default     = 300
+}
+
+variable "evaluation_periods" {
+  description = "The number of periods over which data is compared to the specified threshold."
+  default     = 3
+}
+
+variable "datapoints_to_alarm" {
+  description = "The number of datapoints that must be breaching to trigger the alarm."
+  default     = 3
+}
+
+variable "alarm_actions" {
+  type        = "list"
+  description = "The list of actions to execute when this alarm transitions into an ALARM state from any other state. Each action is specified as an Amazon Resource Name (ARN)."
+  default     = []
+}
+
+variable "tags" {
+  type        = "map"
+  description = "Tags to attach to resources"
+}

--- a/infra/terraform/platform/main.tf
+++ b/infra/terraform/platform/main.tf
@@ -230,7 +230,7 @@ module "kubernetes_master_asg_monitoring" {
   source = "../modules/asg_cloudwatch_alerts"
 
   name          = "${terraform.workspace}-kubernetes-master-asg-alerts"
-  asg_names     = ["master-eu-west-1a.masters.${terraform.workspace}.mojanalytics.xyz", "master-eu-west-1b.masters.${terraform.workspace}.mojanalytics.xyz", "master-eu-west-1c.masters.${terraform.workspace}.mojanalytics.xyz"]
+  asg_names     = ["master-${var.region}a.masters.${terraform.workspace}.mojanalytics.xyz", "master-${var.region}b.masters.${terraform.workspace}.mojanalytics.xyz", "master-${var.region}c.masters.${terraform.workspace}.mojanalytics.xyz"]
   alarm_actions = ["${module.ap_infra_alert_topic.stack_notifications_arn}"]
 
   tags = "${merge(map(

--- a/infra/terraform/platform/main.tf
+++ b/infra/terraform/platform/main.tf
@@ -226,6 +226,18 @@ module "kubernetes_master_monitoring" {
   ), var.tags)}"
 }
 
+module "kubernetes_master_asg_monitoring" {
+  source = "../modules/asg_cloudwatch_alerts"
+
+  name          = "${terraform.workspace}-kubernetes-master-asg-alerts"
+  asg_names     = ["master-eu-west-1a.masters.${terraform.workspace}.mojanalytics.xyz", "master-eu-west-1b.masters.${terraform.workspace}.mojanalytics.xyz", "master-eu-west-1c.masters.${terraform.workspace}.mojanalytics.xyz"]
+  alarm_actions = ["${module.ap_infra_alert_topic.stack_notifications_arn}"]
+
+  tags = "${merge(map(
+    "component", "Kubernetes",
+  ), var.tags)}"
+}
+
 module "bastion_monitoring" {
   source = "../modules/elb_cloudwatch_alerts"
 


### PR DESCRIPTION
We want to send an alert of the CPU usage on the Kubernetes master nodes is high for a sustained period.

As the Kubernetes master nodes are in AutoScaling groups we need to put the monitoring on the Auto scaling groups rather than the individual EC2 instances as the instance IDs of these could change.

- Add a module to create an alert rule for high CPU usage in an Autoscaling group
- Use this module to create alerts for each of the Auto scaling groups used by the Kubernetes master nodes.