### PR TITLE
Change to treat missing surge queue data as not breaching to prevent false alarms

### DIFF
--- a/infra/terraform/modules/elb_cloudwatch_alerts/cloudwatch.tf
+++ b/infra/terraform/modules/elb_cloudwatch_alerts/cloudwatch.tf
@@ -38,7 +38,7 @@ resource "aws_cloudwatch_metric_alarm" "surge_queue_length" {
   period              = "${var.period}"
   evaluation_periods  = "${var.evaluation_periods}"
   datapoints_to_alarm = "${var.datapoints_to_alarm}"
-  treat_missing_data  = "breaching"
+  treat_missing_data  = "notBreaching"
 
   actions_enabled = "true"
   alarm_actions   = ["${var.alarm_actions}"]


### PR DESCRIPTION
Elastic Load balancers don't send any metrics for surge queue length if they don't receive any requests in the sampling period.

Therefore it makes sense to treat missing metrics for surge queue length as Not breaching the alarms to prevent receiving false alarms.