### PR TITLE
Correct metric for desired instances to use Maximum instead of Count

### DIFF
--- a/infra/terraform/modules/asg_cloudwatch_alerts/cloudwatch.tf
+++ b/infra/terraform/modules/asg_cloudwatch_alerts/cloudwatch.tf
@@ -35,7 +35,7 @@ resource "aws_cloudwatch_metric_alarm" "desired_capacity" {
 
   namespace           = "AWS/EC2"
   metric_name         = "GroupDesiredCapacity"
-  statistic           = "Count"
+  statistic           = "Maximum"
   comparison_operator = "GreaterThanThreshold"
   threshold           = "${var.desired_capacity_threshold}"
   period              = "${var.period}"


### PR DESCRIPTION
The alarm for Desired instances for Auto scaling groups should use Maximum for the metric instead of Count (which is not a valid metric)