### PR TITLE
Remove 'shared_analyst' IAM User

### DIFF
--- a/infra/terraform/modules/data_buckets/iam.tf
+++ b/infra/terraform/modules/data_buckets/iam.tf
@@ -113,11 +113,3 @@ resource "aws_iam_group_policy" "analysts_s3" {
 }
 EOF
 }
-
-resource "aws_iam_user" "shared_analyst" {
-  name = "${var.env}-shared-analyst"
-}
-
-resource "aws_iam_access_key" "shared_analyst" {
-  user = "${aws_iam_user.shared_analyst.name}"
-}

--- a/infra/terraform/modules/data_buckets/main.tf
+++ b/infra/terraform/modules/data_buckets/main.tf
@@ -20,14 +20,6 @@ output "scratch_bucket_id" {
   value = "${aws_s3_bucket.scratch.id}"
 }
 
-output "shared_analyst_access_key_id" {
-  value = "${aws_iam_access_key.shared_analyst.id}"
-}
-
-output "shared_analyst_access_key_secret" {
-  value = "${aws_iam_access_key.shared_analyst.secret}"
-}
-
 # CREST bucket
 
 output "crest_bucket_arn" {


### PR DESCRIPTION
Because it's not been used in a long time:
* No console creds
* Access keys last used 2017.
* Access Advisor agrees there's been no access in 400 days

And there's nothing about this user elsewhere in our code.
