### PR TITLE
Adding missing statistic line to EC2 status check

### DIFF
--- a/infra/terraform/modules/cloudwatch_alerts/cloudwatch.tf
+++ b/infra/terraform/modules/cloudwatch_alerts/cloudwatch.tf
@@ -60,6 +60,7 @@ resource "aws_cloudwatch_metric_alarm" "health_monitoring" {
 
   namespace           = "AWS/EC2"
   metric_name         = "StatusCheckFailed"
+  statistic           = "Sum"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   threshold           = "2"
   period              = "${var.period}"


### PR DESCRIPTION
Add a missing line to the check - has been applied successfully.