### PR TITLE
Remove uploads bucket that is maintained by Data Engineering

### DIFF
--- a/infra/terraform/global/iam_upload_users.tf
+++ b/infra/terraform/global/iam_upload_users.tf
@@ -65,10 +65,14 @@ module "ppas_workforce_planning_upload_user" {
 module "lookup_upload_user" {
   source = "../modules/data_bucket_upload_user"
 
-  upload_bucket_arn = "${aws_s3_bucket.lookups.arn}"
+  upload_bucket_arn = "${data.aws_s3_bucket.lookups.arn}"
   system_name       = "lookup"
 }
 
 data "aws_s3_bucket" "uploads" {
   bucket = "mojap-land"
+}
+
+data "aws_s3_bucket" "lookups" {
+  bucket = "moj-analytics-lookup-tables"
 }

--- a/infra/terraform/global/iam_upload_users.tf
+++ b/infra/terraform/global/iam_upload_users.tf
@@ -1,7 +1,7 @@
 module "hmcts_upload_user" {
   source = "../modules/data_upload_user"
 
-  upload_bucket_arn = "${aws_s3_bucket.uploads.arn}"
+  upload_bucket_arn = "${data.aws_s3_bucket.uploads.arn}"
   org_name          = "hmcts"
   system_name       = "azure"
 }
@@ -9,7 +9,7 @@ module "hmcts_upload_user" {
 module "hmpps_nomis_upload_user" {
   source = "../modules/data_upload_user"
 
-  upload_bucket_arn = "${aws_s3_bucket.uploads.arn}"
+  upload_bucket_arn = "${data.aws_s3_bucket.uploads.arn}"
   org_name          = "hmpps"
   system_name       = "nomis"
 }
@@ -17,7 +17,7 @@ module "hmpps_nomis_upload_user" {
 module "hmpps_oasys_upload_user" {
   source = "../modules/data_upload_user"
 
-  upload_bucket_arn = "${aws_s3_bucket.uploads.arn}"
+  upload_bucket_arn = "${data.aws_s3_bucket.uploads.arn}"
   org_name          = "hmpps"
   system_name       = "oasys"
 }
@@ -25,7 +25,7 @@ module "hmpps_oasys_upload_user" {
 module "hmpps_prisonss_upload_user" {
   source = "../modules/data_upload_user"
 
-  upload_bucket_arn = "${aws_s3_bucket.uploads.arn}"
+  upload_bucket_arn = "${data.aws_s3_bucket.uploads.arn}"
   org_name          = "hmpps"
   system_name       = "prison-selfservice"
 }
@@ -33,7 +33,7 @@ module "hmpps_prisonss_upload_user" {
 module "hmpps_prisoner_money_user" {
   source = "../modules/data_upload_user"
 
-  upload_bucket_arn = "${aws_s3_bucket.uploads.arn}"
+  upload_bucket_arn = "${data.aws_s3_bucket.uploads.arn}"
   org_name          = "hmpps"
   system_name       = "prisoner-money"
 }
@@ -41,7 +41,7 @@ module "hmpps_prisoner_money_user" {
 module "laa_cla_upload_user" {
   source = "../modules/data_upload_user"
 
-  upload_bucket_arn = "${aws_s3_bucket.uploads.arn}"
+  upload_bucket_arn = "${data.aws_s3_bucket.uploads.arn}"
   org_name          = "laa"
   system_name       = "cla"
 }
@@ -49,7 +49,7 @@ module "laa_cla_upload_user" {
 module "ppas_mdt_upload_user" {
   source = "../modules/data_upload_user"
 
-  upload_bucket_arn = "${aws_s3_bucket.uploads.arn}"
+  upload_bucket_arn = "${data.aws_s3_bucket.uploads.arn}"
   org_name          = "ppas"
   system_name       = "mdt"
 }
@@ -57,7 +57,7 @@ module "ppas_mdt_upload_user" {
 module "ppas_workforce_planning_upload_user" {
   source = "../modules/data_upload_user"
 
-  upload_bucket_arn = "${aws_s3_bucket.uploads.arn}"
+  upload_bucket_arn = "${data.aws_s3_bucket.uploads.arn}"
   org_name          = "ppas"
   system_name       = "workforce-planning"
 }
@@ -67,4 +67,8 @@ module "lookup_upload_user" {
 
   upload_bucket_arn = "${aws_s3_bucket.lookups.arn}"
   system_name       = "lookup"
+}
+
+data "aws_s3_bucket" "uploads" {
+  bucket = "mojap-land"
 }

--- a/infra/terraform/global/s3.tf
+++ b/infra/terraform/global/s3.tf
@@ -16,24 +16,6 @@ resource "aws_s3_bucket" "kops_state" {
   }
 }
 
-resource "aws_s3_bucket" "uploads" {
-  bucket = "${var.uploads_bucket_name}"
-  region = "${var.region}"
-  acl    = "private"
-
-  versioning {
-    enabled = true
-  }
-
-  server_side_encryption_configuration {
-    rule {
-      apply_server_side_encryption_by_default {
-        sse_algorithm = "AES256"
-      }
-    }
-  }
-}
-
 resource "aws_s3_bucket" "lookups" {
   bucket = "${var.lookups_bucket_name}"
   region = "${var.region}"

--- a/infra/terraform/global/s3.tf
+++ b/infra/terraform/global/s3.tf
@@ -15,21 +15,3 @@ resource "aws_s3_bucket" "kops_state" {
     }
   }
 }
-
-resource "aws_s3_bucket" "lookups" {
-  bucket = "${var.lookups_bucket_name}"
-  region = "${var.region}"
-  acl    = "private"
-
-  versioning {
-    enabled = true
-  }
-
-  server_side_encryption_configuration {
-    rule {
-      apply_server_side_encryption_by_default {
-        sse_algorithm = "AES256"
-      }
-    }
-  }
-}

--- a/infra/terraform/global/variables.tf
+++ b/infra/terraform/global/variables.tf
@@ -13,10 +13,6 @@ variable "es_scheme" {
   default = "https"
 }
 
-variable "lookups_bucket_name" {
-  default = "moj-analytics-lookup-tables"
-}
-
 variable "global_cloudtrail_bucket_name" {
   default = "moj-analytics-global-cloudtrail"
 }

--- a/infra/terraform/global/variables.tf
+++ b/infra/terraform/global/variables.tf
@@ -13,10 +13,6 @@ variable "es_scheme" {
   default = "https"
 }
 
-variable "uploads_bucket_name" {
-  default = "mojap-land"
-}
-
 variable "lookups_bucket_name" {
   default = "moj-analytics-lookup-tables"
 }


### PR DESCRIPTION
This bucket used to be maintained by the Analytical Platform, but now is
maintained by the data engineering team. This has led to a situation
where both Pulumi and Terraform are trying to manage the same resource.

This PR removes it from Terraform. We will also remove it from state as
part of this PR so Terraform forgets about the resource and Pulumi can
continue to maintain it.


