### PR TITLE
Upgrade to Terraform 0.12

### DIFF
--- a/infra/terraform/global/assets/vpcflowlogs/Makefile
+++ b/infra/terraform/global/assets/vpcflowlogs/Makefile
@@ -1,0 +1,4 @@
+SHELL = '/bin/bash'
+
+build:
+	pip3 install -r requirements.txt --upgrade -t ./package

--- a/infra/terraform/global/assets/vpcflowlogs/app.py
+++ b/infra/terraform/global/assets/vpcflowlogs/app.py
@@ -1,0 +1,78 @@
+import datetime
+import gzip
+import logging
+import os
+from itertools import islice
+import boto3
+import certifi
+import elasticsearch.helpers
+import jsonpickle
+from elasticsearch import Elasticsearch
+from flowlogs_reader import FlowRecord
+
+LOG = logging.getLogger(__name__)
+LOG.setLevel(os.environ.get('LOG_LEVEL', 'DEBUG'))
+
+creds = os.environ['ES_USERNAME'] + ':' + os.environ['ES_PASSWORD']
+
+es = Elasticsearch(
+    host=os.environ['ES_DOMAIN'],
+    port=os.environ['ES_PORT'],
+    http_auth=creds,
+    use_ssl=True,
+    verify_certs=True,
+    ca_certs=certifi.where(),
+    timeout=120
+)
+
+index = 'flow-log'
+index_type = 'lambda-type'
+
+s3 = boto3.client('s3')
+
+
+# Lambda execution starts here
+def lambda_handler(event, context):
+    for record in event['Records']:
+
+        # Get the bucket name and key for the new file
+        bucket = record['s3']['bucket']['name']
+        key = record['s3']['object']['key']
+
+        # Get, read, and split the file into lines
+        obj = s3.get_object(Bucket=bucket, Key=key)
+        body = gzip.decompress(obj['Body'].read())
+        lines = body.decode('UTF-8').splitlines()
+
+        # Post logs to elasticsearch
+        elasticsearch.helpers.bulk(es, log_data(lines), index=index)
+
+
+# Convert each log line to JSON
+def log_data(lines):
+    # Skip heading line in log file
+    for line in islice(lines, 1, None):
+
+        # Marshal log event to slot\dictionary
+        line_dict = FlowRecord.from_message(line)
+
+        # Marshal log event to JSON and strip python metadata
+        document = jsonpickle.encode(line_dict, unpicklable=False)
+
+        yield {
+            '_op_type': 'index',
+            '_index': elasticsearch_index(index),
+            '_type': index_type,
+            'timestamp': line_dict.start,
+            '_source': document,
+        }
+
+
+# Set index name format flow-log-yyyy.mm.dd
+def elasticsearch_index(prefix, today=None):
+    if today is None:
+        today = datetime.datetime.utcnow()
+
+    return '{prefix}-{date:%Y.%m.%d}'.format(
+        prefix=prefix,
+        date=today)

--- a/infra/terraform/global/assets/vpcflowlogs/requirements.txt
+++ b/infra/terraform/global/assets/vpcflowlogs/requirements.txt
@@ -1,0 +1,5 @@
+# Elasticsearch 6.x
+elasticsearch>=6.0.0,<7.0.0
+certifi
+flowlogs_reader==1.1.1
+jsonpickle

--- a/infra/terraform/global/cloudtrail.tf
+++ b/infra/terraform/global/cloudtrail.tf
@@ -98,23 +98,24 @@ resource "aws_kms_key" "cloudtrail" {
   ]
 }
 POLICY
+
 }
 
 resource "aws_kms_alias" "cloudtrail" {
   name          = "alias/cloudtrail"
-  target_key_id = "${aws_kms_key.cloudtrail.key_id}"
+  target_key_id = aws_kms_key.cloudtrail.key_id
 }
 
 resource "aws_cloudtrail" "global" {
   name                       = "global"
-  s3_bucket_name             = "${aws_s3_bucket.global_cloudtrail.id}"
+  s3_bucket_name             = aws_s3_bucket.global_cloudtrail.id
   is_multi_region_trail      = true
   enable_log_file_validation = true
-  kms_key_id                 = "${aws_kms_key.cloudtrail.arn}"
+  kms_key_id                 = aws_kms_key.cloudtrail.arn
 }
 
 resource "aws_s3_bucket" "global_cloudtrail" {
-  bucket        = "${var.global_cloudtrail_bucket_name}"
+  bucket        = var.global_cloudtrail_bucket_name
   force_destroy = false
 
   lifecycle_rule {
@@ -176,4 +177,5 @@ resource "aws_s3_bucket" "global_cloudtrail" {
     ]
 }
 POLICY
+
 }

--- a/infra/terraform/global/dns.tf
+++ b/infra/terraform/global/dns.tf
@@ -8,15 +8,15 @@ resource "aws_route53_zone" "global" {
 }
 
 resource "aws_route53_record" "global_ns" {
-  zone_id = "${aws_route53_zone.platform_zone.zone_id}"
-  name    = "${aws_route53_zone.global.name}"
+  zone_id = aws_route53_zone.platform_zone.zone_id
+  name    = aws_route53_zone.global.name
   type    = "NS"
   ttl     = "30"
 
   records = [
-    "${aws_route53_zone.global.name_servers.0}",
-    "${aws_route53_zone.global.name_servers.1}",
-    "${aws_route53_zone.global.name_servers.2}",
-    "${aws_route53_zone.global.name_servers.3}",
+    aws_route53_zone.global.name_servers[0],
+    aws_route53_zone.global.name_servers[1],
+    aws_route53_zone.global.name_servers[2],
+    aws_route53_zone.global.name_servers[3],
   ]
 }

--- a/infra/terraform/global/ebs_snapshots.tf
+++ b/infra/terraform/global/ebs_snapshots.tf
@@ -2,7 +2,9 @@
 
 // Create Snapshot policy document
 data "template_file" "lambda_create_snapshot_policy" {
-  template = "${file("assets/create_etcd_ebs_snapshot/lambda_create_snapshot_policy.json")}"
+  template = file(
+    "assets/create_etcd_ebs_snapshot/lambda_create_snapshot_policy.json",
+  )
 }
 
 // Lambda requires that we zip the distribution in order to deploy it
@@ -17,15 +19,15 @@ module "kubernetes_etcd_ebs_snapshot" {
   lambda_function_name  = "create_etcd_ebs_snapshot"
   zipfile               = "assets/create_etcd_ebs_snapshot/create_etcd_ebs_snapshot.zip"
   handler               = "create_etcd_ebs_snapshot"
-  source_code_hash      = "${data.archive_file.kubernetes_etcd_ebs_snapshot_code.output_base64sha256}"
-  lamda_policy          = "${data.template_file.lambda_create_snapshot_policy.rendered}"
-  environment_variables = "${var.create_etcd_ebs_snapshot_env_vars}"
+  source_code_hash      = data.archive_file.kubernetes_etcd_ebs_snapshot_code.output_base64sha256
+  lamda_policy          = data.template_file.lambda_create_snapshot_policy.rendered
+  environment_variables = var.create_etcd_ebs_snapshot_env_vars
 }
 
 // Prune snapshots -->
 
 data "template_file" "lambda_prune_ebs_snapshots_policy" {
-  template = "${file("assets/prune_ebs_snapshots/prune_ebs_snapshots_policy.json")}"
+  template = file("assets/prune_ebs_snapshots/prune_ebs_snapshots_policy.json")
 }
 
 // Lambda requires that we zip the distribution in order to deploy it
@@ -40,7 +42,8 @@ module "kubernetes_prune_ebs_snapshots" {
   lambda_function_name  = "prune_ebs_snapshots"
   zipfile               = "assets/prune_ebs_snapshots/prune_ebs_snapshots.zip"
   handler               = "prune_ebs_snapshots"
-  source_code_hash      = "${data.archive_file.kubernetes_prune_ebs_snapshots_code.output_base64sha256}"
-  lamda_policy          = "${data.template_file.lambda_prune_ebs_snapshots_policy.rendered}"
-  environment_variables = "${var.prune_etcd_ebs_snapshot_env_vars}"
+  source_code_hash      = data.archive_file.kubernetes_prune_ebs_snapshots_code.output_base64sha256
+  lamda_policy          = data.template_file.lambda_prune_ebs_snapshots_policy.rendered
+  environment_variables = var.prune_etcd_ebs_snapshot_env_vars
 }
+

--- a/infra/terraform/global/iam.tf
+++ b/infra/terraform/global/iam.tf
@@ -4,8 +4,8 @@ resource "aws_iam_user" "auth0_ses" {
 
 resource "aws_iam_user_policy" "auth0_ses" {
   name   = "auth0_ses_user_policy"
-  user   = "${aws_iam_user.auth0_ses.name}"
-  policy = "${data.aws_iam_policy_document.auth0_ses.json}"
+  user   = aws_iam_user.auth0_ses.name
+  policy = data.aws_iam_policy_document.auth0_ses.json
 }
 
 data "aws_iam_policy_document" "auth0_ses" {
@@ -21,12 +21,12 @@ data "aws_iam_policy_document" "auth0_ses" {
 }
 
 resource "aws_iam_access_key" "auth0_ses" {
-  user = "${aws_iam_user.auth0_ses.name}"
+  user = aws_iam_user.auth0_ses.name
 }
 
 resource "aws_iam_role" "softnas" {
   name               = "SoftNAS_HA_IAM"
-  assume_role_policy = "${data.aws_iam_policy_document.softnas_role.json}"
+  assume_role_policy = data.aws_iam_policy_document.softnas_role.json
 }
 
 data "aws_iam_policy_document" "softnas_role" {
@@ -43,8 +43,8 @@ data "aws_iam_policy_document" "softnas_role" {
 
 resource "aws_iam_role_policy" "softnas" {
   name   = "softnas_ha_policy"
-  role   = "${aws_iam_role.softnas.id}"
-  policy = "${data.aws_iam_policy_document.softnas.json}"
+  role   = aws_iam_role.softnas.id
+  policy = data.aws_iam_policy_document.softnas.json
 }
 
 data "aws_iam_policy_document" "softnas" {
@@ -92,13 +92,13 @@ resource "aws_iam_user" "concourse_update_helm_repo" {
 }
 
 resource "aws_iam_access_key" "concourse_update_helm_repo_access_key" {
-  user = "${aws_iam_user.concourse_update_helm_repo.name}"
+  user = aws_iam_user.concourse_update_helm_repo.name
 }
 
 resource "aws_iam_user_policy" "concourse_update_helm_repo_policy" {
   name   = "${aws_iam_user.concourse_update_helm_repo.name}_policy"
-  user   = "${aws_iam_user.concourse_update_helm_repo.name}"
-  policy = "${data.aws_iam_policy_document.concourse.json}"
+  user   = aws_iam_user.concourse_update_helm_repo.name
+  policy = data.aws_iam_policy_document.concourse.json
 }
 
 data "aws_iam_policy_document" "concourse" {

--- a/infra/terraform/global/main.tf
+++ b/infra/terraform/global/main.tf
@@ -8,31 +8,32 @@ terraform {
 }
 
 provider "aws" {
-  region  = "${var.region}"
-  version = "~> 1.51.0"
+  region  = var.region
+  version = "~> 2.70.0"
 }
 
-data "aws_caller_identity" "current" {}
+data "aws_caller_identity" "current" {
+}
 
 module "aws_account_logging" {
   source = "./modules/aws_account_logging"
 
-  es_domain   = "${var.es_domain}"
-  es_port     = "${var.es_port}"
-  es_scheme   = "${var.es_scheme}"
-  es_username = "${var.es_username}"
-  es_password = "${var.es_password}"
+  es_domain   = var.es_domain
+  es_port     = var.es_port
+  es_scheme   = var.es_scheme
+  es_username = var.es_username
+  es_password = var.es_password
 
-  cloudtrail_s3_bucket_arn = "${aws_s3_bucket.global_cloudtrail.arn}"
-  cloudtrail_s3_bucket_id  = "${aws_s3_bucket.global_cloudtrail.id}"
+  cloudtrail_s3_bucket_arn = aws_s3_bucket.global_cloudtrail.arn
+  cloudtrail_s3_bucket_id  = aws_s3_bucket.global_cloudtrail.id
 
-  account_id = "${data.aws_caller_identity.current.account_id}"
+  account_id = data.aws_caller_identity.current.account_id
 
-  s3_logs_bucket_name = "${var.s3_logs_bucket_name}"
+  s3_logs_bucket_name = var.s3_logs_bucket_name
 
-  vpcflowlogs_s3_bucket_name = "${var.vpcflowlogs_s3_bucket_name}"
+  vpcflowlogs_s3_bucket_name = var.vpcflowlogs_s3_bucket_name
 
-  vpc_id = "${var.vpc_id}"
+  vpc_id = var.vpc_id
 }
 
 module "mojanalytics_concourse_iam_list_roles_user" {
@@ -43,7 +44,7 @@ module "mojanalytics_concourse_iam_list_roles_user" {
 
 module "ses_domain" {
   source = "./modules/ses_domain"
-  domain = "${var.platform_root_domain}"
+  domain = var.platform_root_domain
 
-  aws_route53_zone_id = "${aws_route53_zone.platform_zone.zone_id}"
+  aws_route53_zone_id = aws_route53_zone.platform_zone.zone_id
 }

--- a/infra/terraform/global/modules/aws_account_logging/aws-flow-log.tf
+++ b/infra/terraform/global/modules/aws_account_logging/aws-flow-log.tf
@@ -1,7 +1,7 @@
 resource "aws_flow_log" "vpcflowlogs_to_s3" {
-  iam_role_arn         = "${aws_iam_role.vpcflowlogs_to_elasticsearch_role.arn}"
+  iam_role_arn         = aws_iam_role.vpcflowlogs_to_elasticsearch_role.arn
   log_destination_type = "s3"
-  log_destination      = "${aws_s3_bucket.vpcflowlogs_bucket.arn}"
+  log_destination      = aws_s3_bucket.vpcflowlogs_bucket.arn
   traffic_type         = "ALL"
-  vpc_id               = "${var.vpc_id}"
+  vpc_id               = var.vpc_id
 }

--- a/infra/terraform/global/modules/aws_account_logging/cloudtrail-lambda.tf
+++ b/infra/terraform/global/modules/aws_account_logging/cloudtrail-lambda.tf
@@ -4,8 +4,8 @@ resource "null_resource" "cloudtrail_install_deps" {
     command = "${path.module}/cloudtrail/build.sh"
   }
 
-  triggers {
-    force_rebuild = "${timestamp()}"
+  triggers = {
+    force_rebuild = timestamp()
   }
 }
 
@@ -15,28 +15,28 @@ data "archive_file" "cloudtrail_zip" {
   source_dir  = "${path.module}/cloudtrail"
   output_path = "/tmp/cloudtrail.zip"
 
-  depends_on = ["null_resource.cloudtrail_install_deps"]
+  depends_on = [null_resource.cloudtrail_install_deps]
 }
 
 # Lambda function to ship Cloudtrail logs to Elasticsearch cluster
 resource "aws_lambda_function" "cloudtrail_to_elasticsearch" {
   description      = "Ships Cloudtrail logs to Elasticsearch"
   filename         = "/tmp/cloudtrail.zip"
-  source_code_hash = "${data.archive_file.cloudtrail_zip.output_base64sha256}"
+  source_code_hash = data.archive_file.cloudtrail_zip.output_base64sha256
   function_name    = "cloudtrail_to_elasticsearch"
-  role             = "${aws_iam_role.cloudtrail_to_elasticsearch.arn}"
+  role             = aws_iam_role.cloudtrail_to_elasticsearch.arn
   handler          = "cloudtrail_to_es.lambda_handler"
   runtime          = "python3.6"
   timeout          = 30
-  depends_on       = ["data.archive_file.cloudtrail_zip"]
+  depends_on       = [data.archive_file.cloudtrail_zip]
 
   environment {
     variables = {
-      ES_DOMAIN   = "${var.es_domain}"
-      ES_PORT     = "${var.es_port}"
-      ES_SCHEME   = "${var.es_scheme}"
-      ES_USERNAME = "${var.es_username}"
-      ES_PASSWORD = "${var.es_password}"
+      ES_DOMAIN   = var.es_domain
+      ES_PORT     = var.es_port
+      ES_SCHEME   = var.es_scheme
+      ES_USERNAME = var.es_username
+      ES_PASSWORD = var.es_password
     }
   }
 }
@@ -45,17 +45,17 @@ resource "aws_lambda_function" "cloudtrail_to_elasticsearch" {
 resource "aws_lambda_permission" "allow_cloudtrail_bucket" {
   statement_id  = "AllowExecutionFromS3Bucket"
   action        = "lambda:InvokeFunction"
-  function_name = "${aws_lambda_function.cloudtrail_to_elasticsearch.arn}"
+  function_name = aws_lambda_function.cloudtrail_to_elasticsearch.arn
   principal     = "s3.amazonaws.com"
-  source_arn    = "${var.cloudtrail_s3_bucket_arn}"
+  source_arn    = var.cloudtrail_s3_bucket_arn
 }
 
 # Trigger Lambda function from S3 object created event
 resource "aws_s3_bucket_notification" "cloudtrail_object_created" {
-  bucket = "${var.cloudtrail_s3_bucket_id}"
+  bucket = var.cloudtrail_s3_bucket_id
 
   lambda_function {
-    lambda_function_arn = "${aws_lambda_function.cloudtrail_to_elasticsearch.arn}"
+    lambda_function_arn = aws_lambda_function.cloudtrail_to_elasticsearch.arn
     events              = ["s3:ObjectCreated:*"]
     filter_prefix       = "AWSLogs/${var.account_id}/CloudTrail/"
   }

--- a/infra/terraform/global/modules/aws_account_logging/iam.tf
+++ b/infra/terraform/global/modules/aws_account_logging/iam.tf
@@ -3,7 +3,7 @@ data "aws_iam_policy_document" "lambda_assume_role" {
     actions = ["sts:AssumeRole"]
     effect  = "Allow"
 
-    principals = {
+    principals {
       type        = "Service"
       identifiers = ["lambda.amazonaws.com"]
     }
@@ -13,13 +13,13 @@ data "aws_iam_policy_document" "lambda_assume_role" {
 # Role assumed by the 'ship_s3_logs_to_elasticsearch' lambda function
 resource "aws_iam_role" "s3_logs_to_elasticsearch" {
   name               = "s3_logs_to_elasticsearch"
-  assume_role_policy = "${data.aws_iam_policy_document.lambda_assume_role.json}"
+  assume_role_policy = data.aws_iam_policy_document.lambda_assume_role.json
 }
 
 # Policies for the 'ship_s3_logs_to_elasticsearch' role
 resource "aws_iam_role_policy" "s3_logs_to_elasticsearch" {
   name = "s3_logs_to_elasticsearch"
-  role = "${aws_iam_role.s3_logs_to_elasticsearch.id}"
+  role = aws_iam_role.s3_logs_to_elasticsearch.id
 
   policy = <<EOF
 {
@@ -57,18 +57,19 @@ resource "aws_iam_role_policy" "s3_logs_to_elasticsearch" {
   ]
 }
 EOF
+
 }
 
 # Role assumed by the 'ship_cloudtrail_to_elasticsearch' lambda function
 resource "aws_iam_role" "cloudtrail_to_elasticsearch" {
   name               = "cloudtrail_to_elasticsearch"
-  assume_role_policy = "${data.aws_iam_policy_document.lambda_assume_role.json}"
+  assume_role_policy = data.aws_iam_policy_document.lambda_assume_role.json
 }
 
 # Policies for the 'ship_cloudtrail_to_elasticsearch' role
 resource "aws_iam_role_policy" "cloudtrail_to_elasticsearch" {
   name = "cloudtrail_to_elasticsearch"
-  role = "${aws_iam_role.cloudtrail_to_elasticsearch.id}"
+  role = aws_iam_role.cloudtrail_to_elasticsearch.id
 
   policy = <<EOF
 {
@@ -106,12 +107,13 @@ resource "aws_iam_role_policy" "cloudtrail_to_elasticsearch" {
   ]
 }
 EOF
+
 }
 
 # VPC flow logs
 
 data "aws_iam_policy_document" "vpcflowlogs_assume_role_policy_document" {
-  "statement" {
+  statement {
     effect  = "Allow"
     actions = ["sts:AssumeRole"]
 
@@ -128,7 +130,7 @@ data "aws_iam_policy_document" "vpcflowlogs_assume_role_policy_document" {
 }
 
 data "aws_iam_policy_document" "vpcflowlogs_policy_document" {
-  "statement" {
+  statement {
     sid    = "CanLog"
     effect = "Allow"
 
@@ -154,7 +156,7 @@ data "aws_iam_policy_document" "vpcflowlogs_policy_document" {
       "s3:PutBucketPolicy",
     ]
 
-    resources = ["${aws_s3_bucket.vpcflowlogs_bucket.arn}"]
+    resources = [aws_s3_bucket.vpcflowlogs_bucket.arn]
   }
 
   statement {
@@ -174,15 +176,15 @@ data "aws_iam_policy_document" "vpcflowlogs_policy_document" {
 
 resource "aws_iam_role" "vpcflowlogs_to_elasticsearch_role" {
   name               = "vpcflowlogs_to_elasticsearch"
-  assume_role_policy = "${data.aws_iam_policy_document.vpcflowlogs_assume_role_policy_document.json}"
+  assume_role_policy = data.aws_iam_policy_document.vpcflowlogs_assume_role_policy_document.json
 }
 
 resource "aws_iam_policy" "vpcflowlogs_to_elasticsearch_policy" {
-  policy = "${data.aws_iam_policy_document.vpcflowlogs_policy_document.json}"
+  policy = data.aws_iam_policy_document.vpcflowlogs_policy_document.json
   name   = "vpcflowlogs_to_elasticsearch"
 }
 
 resource "aws_iam_role_policy_attachment" "vpcflowlogs_to_elasticsearch_policy_attachment" {
-  policy_arn = "${aws_iam_policy.vpcflowlogs_to_elasticsearch_policy.arn}"
-  role       = "${aws_iam_role.vpcflowlogs_to_elasticsearch_role.name}"
+  policy_arn = aws_iam_policy.vpcflowlogs_to_elasticsearch_policy.arn
+  role       = aws_iam_role.vpcflowlogs_to_elasticsearch_role.name
 }

--- a/infra/terraform/global/modules/aws_account_logging/lambda.tf
+++ b/infra/terraform/global/modules/aws_account_logging/lambda.tf
@@ -4,8 +4,8 @@ resource "null_resource" "s3logs_install_deps" {
     command = "${path.module}/s3logs/build.sh"
   }
 
-  triggers {
-    force_rebuild = "${timestamp()}"
+  triggers = {
+    force_rebuild = timestamp()
   }
 }
 
@@ -15,28 +15,28 @@ data "archive_file" "s3logs_zip" {
   source_dir  = "${path.module}/s3logs"
   output_path = "/tmp/s3logs.zip"
 
-  depends_on = ["null_resource.s3logs_install_deps"]
+  depends_on = [null_resource.s3logs_install_deps]
 }
 
 # Lambda function to ship S3 access logs to Elasticsearch cluster
 resource "aws_lambda_function" "s3_logs_to_elasticsearch" {
   description      = "Ships s3 access logs to Elasticsearch"
   filename         = "/tmp/s3logs.zip"
-  source_code_hash = "${data.archive_file.s3logs_zip.output_base64sha256}"
+  source_code_hash = data.archive_file.s3logs_zip.output_base64sha256
   function_name    = "s3_logs_to_elasticsearch"
-  role             = "${aws_iam_role.s3_logs_to_elasticsearch.arn}"
+  role             = aws_iam_role.s3_logs_to_elasticsearch.arn
   handler          = "s3_to_es.lambda_handler"
   runtime          = "python3.6"
   timeout          = 5
-  depends_on       = ["data.archive_file.s3logs_zip"]
+  depends_on       = [data.archive_file.s3logs_zip]
 
   environment {
     variables = {
-      ES_DOMAIN   = "${var.es_domain}"
-      ES_PORT     = "${var.es_port}"
-      ES_SCHEME   = "${var.es_scheme}"
-      ES_USERNAME = "${var.es_username}"
-      ES_PASSWORD = "${var.es_password}"
+      ES_DOMAIN   = var.es_domain
+      ES_PORT     = var.es_port
+      ES_SCHEME   = var.es_scheme
+      ES_USERNAME = var.es_username
+      ES_PASSWORD = var.es_password
     }
   }
 }
@@ -45,17 +45,17 @@ resource "aws_lambda_function" "s3_logs_to_elasticsearch" {
 resource "aws_lambda_permission" "allow_s3_logs_bucket" {
   statement_id  = "AllowExecutionFromS3Bucket"
   action        = "lambda:InvokeFunction"
-  function_name = "${aws_lambda_function.s3_logs_to_elasticsearch.arn}"
+  function_name = aws_lambda_function.s3_logs_to_elasticsearch.arn
   principal     = "s3.amazonaws.com"
-  source_arn    = "${aws_s3_bucket.s3_logs.arn}"
+  source_arn    = aws_s3_bucket.s3_logs.arn
 }
 
 # Trigger Lambda function from S3 object created event
 resource "aws_s3_bucket_notification" "s3_logs_object_created" {
-  bucket = "${aws_s3_bucket.s3_logs.id}"
+  bucket = aws_s3_bucket.s3_logs.id
 
   lambda_function {
-    lambda_function_arn = "${aws_lambda_function.s3_logs_to_elasticsearch.arn}"
+    lambda_function_arn = aws_lambda_function.s3_logs_to_elasticsearch.arn
     events              = ["s3:ObjectCreated:*"]
   }
 }

--- a/infra/terraform/global/modules/aws_account_logging/main.tf
+++ b/infra/terraform/global/modules/aws_account_logging/main.tf
@@ -1,17 +1,33 @@
-variable "es_domain" {}
-variable "es_port" {}
-variable "es_username" {}
-variable "es_password" {}
+variable "es_domain" {
+}
+
+variable "es_port" {
+}
+
+variable "es_username" {
+}
+
+variable "es_password" {
+}
 
 variable "es_scheme" {
   default = "https"
 }
 
-variable "cloudtrail_s3_bucket_id" {}
-variable "cloudtrail_s3_bucket_arn" {}
-variable "account_id" {}
-variable "s3_logs_bucket_name" {}
+variable "cloudtrail_s3_bucket_id" {
+}
 
-variable "vpcflowlogs_s3_bucket_name" {}
+variable "cloudtrail_s3_bucket_arn" {
+}
 
-variable "vpc_id" {}
+variable "account_id" {
+}
+
+variable "s3_logs_bucket_name" {
+}
+
+variable "vpcflowlogs_s3_bucket_name" {
+}
+
+variable "vpc_id" {
+}

--- a/infra/terraform/global/modules/aws_account_logging/outputs.tf
+++ b/infra/terraform/global/modules/aws_account_logging/outputs.tf
@@ -1,7 +1,7 @@
 output "s3_logs_bucket_name" {
-  value = "${aws_s3_bucket.s3_logs.id}"
+  value = aws_s3_bucket.s3_logs.id
 }
 
 output "cloudtrail_bucket_name" {
-  value = "${var.cloudtrail_s3_bucket_id}"
+  value = var.cloudtrail_s3_bucket_id
 }

--- a/infra/terraform/global/modules/aws_account_logging/s3.tf
+++ b/infra/terraform/global/modules/aws_account_logging/s3.tf
@@ -1,5 +1,5 @@
 resource "aws_s3_bucket" "s3_logs" {
-  bucket = "${var.s3_logs_bucket_name}"
+  bucket = var.s3_logs_bucket_name
   acl    = "log-delivery-write"
 
   lifecycle_rule {
@@ -23,7 +23,7 @@ resource "aws_s3_bucket" "s3_logs" {
     }
   }
 
-  tags {
+  tags = {
     Name = "moj-analytics-s3-logs"
   }
 
@@ -37,7 +37,7 @@ resource "aws_s3_bucket" "s3_logs" {
 }
 
 resource "aws_s3_bucket" "vpcflowlogs_bucket" {
-  bucket = "${var.vpcflowlogs_s3_bucket_name}"
+  bucket = var.vpcflowlogs_s3_bucket_name
 
   lifecycle_rule {
     enabled                                = true
@@ -59,7 +59,7 @@ resource "aws_s3_bucket" "vpcflowlogs_bucket" {
     }
   }
 
-  tags {
+  tags = {
     Name = "moj-analytics-vpcflowlogs"
   }
 }

--- a/infra/terraform/global/modules/aws_account_logging/versions.tf
+++ b/infra/terraform/global/modules/aws_account_logging/versions.tf
@@ -1,3 +1,4 @@
+
 terraform {
   required_version = ">= 0.12"
 }

--- a/infra/terraform/global/modules/aws_account_logging/vpcflowlogs-lambda.tf
+++ b/infra/terraform/global/modules/aws_account_logging/vpcflowlogs-lambda.tf
@@ -3,8 +3,8 @@ resource "null_resource" "vpcflowlogs_install_deps" {
     command = "${path.module}/vpcflowlogs/build.sh"
   }
 
-  triggers {
-    force_rebuild = "${timestamp()}"
+  triggers = {
+    force_rebuild = timestamp()
   }
 }
 
@@ -17,19 +17,19 @@ data "archive_file" "vpcflowlogs_zip" {
 resource "aws_lambda_function" "vpcflowlogs_to_elasticsearch" {
   function_name    = "vpcflowlogs_to_elasticsearch"
   handler          = "vpcflowlogs_to_elasticsearch.lambda_handler"
-  role             = "${aws_iam_role.vpcflowlogs_to_elasticsearch_role.arn}"
+  role             = aws_iam_role.vpcflowlogs_to_elasticsearch_role.arn
   runtime          = "python3.6"
   timeout          = 30
-  filename         = "${data.archive_file.vpcflowlogs_zip.output_path}"
-  source_code_hash = "${data.archive_file.vpcflowlogs_zip.output_base64sha256}"
+  filename         = data.archive_file.vpcflowlogs_zip.output_path
+  source_code_hash = data.archive_file.vpcflowlogs_zip.output_base64sha256
 
   environment {
     variables = {
-      ES_DOMAIN   = "${var.es_domain}"
-      ES_PORT     = "${var.es_port}"
-      ES_SCHEME   = "${var.es_scheme}"
-      ES_USERNAME = "${var.es_username}"
-      ES_PASSWORD = "${var.es_password}"
+      ES_DOMAIN   = var.es_domain
+      ES_PORT     = var.es_port
+      ES_SCHEME   = var.es_scheme
+      ES_USERNAME = var.es_username
+      ES_PASSWORD = var.es_password
     }
   }
 }
@@ -37,17 +37,17 @@ resource "aws_lambda_function" "vpcflowlogs_to_elasticsearch" {
 resource "aws_lambda_permission" "allow_vpcflowlogs_bucket" {
   statement_id  = "AllowExecutionFromS3Bucket"
   action        = "lambda:InvokeFunction"
-  function_name = "${aws_lambda_function.vpcflowlogs_to_elasticsearch.function_name}"
+  function_name = aws_lambda_function.vpcflowlogs_to_elasticsearch.function_name
   principal     = "s3.amazonaws.com"
-  source_arn    = "${aws_s3_bucket.vpcflowlogs_bucket.arn}"
+  source_arn    = aws_s3_bucket.vpcflowlogs_bucket.arn
 }
 
 resource "aws_s3_bucket_notification" "vpcflowlogs_object_created" {
-  bucket = "${var.vpcflowlogs_s3_bucket_name}"
+  bucket = var.vpcflowlogs_s3_bucket_name
 
   lambda_function {
     events              = ["s3:ObjectCreated:*"]
-    lambda_function_arn = "${aws_lambda_function.vpcflowlogs_to_elasticsearch.arn}"
+    lambda_function_arn = aws_lambda_function.vpcflowlogs_to_elasticsearch.arn
     filter_prefix       = "AWSLogs/${var.account_id}/vpcflowlogs/"
   }
 }

--- a/infra/terraform/global/modules/iam_list_roles/iam.tf
+++ b/infra/terraform/global/modules/iam_list_roles/iam.tf
@@ -4,7 +4,7 @@ resource "aws_iam_user" "system" {
 }
 
 resource "aws_iam_access_key" "system_user" {
-  user = "${aws_iam_user.system.name}"
+  user = aws_iam_user.system.name
 }
 
 data "aws_iam_policy_document" "iam_roles_readonly" {
@@ -24,10 +24,10 @@ data "aws_iam_policy_document" "iam_roles_readonly" {
 resource "aws_iam_policy" "iam_roles_readonly" {
   name   = "${var.org_name}_${var.system_name}_iam_roles_readonly"
   path   = "/iam/${var.org_name}/${var.system_name}/"
-  policy = "${data.aws_iam_policy_document.iam_roles_readonly.json}"
+  policy = data.aws_iam_policy_document.iam_roles_readonly.json
 }
 
 resource "aws_iam_user_policy_attachment" "concourse_list_roles" {
-  user       = "${aws_iam_user.system.name}"
-  policy_arn = "${aws_iam_policy.iam_roles_readonly.arn}"
+  user       = aws_iam_user.system.name
+  policy_arn = aws_iam_policy.iam_roles_readonly.arn
 }

--- a/infra/terraform/global/modules/iam_list_roles/outputs.tf
+++ b/infra/terraform/global/modules/iam_list_roles/outputs.tf
@@ -1,7 +1,7 @@
 output "access_key_id" {
-  value = "${aws_iam_access_key.system_user.id}"
+  value = aws_iam_access_key.system_user.id
 }
 
 output "access_key_secret" {
-  value = "${aws_iam_access_key.system_user.secret}"
+  value = aws_iam_access_key.system_user.secret
 }

--- a/infra/terraform/global/modules/iam_list_roles/variables.tf
+++ b/infra/terraform/global/modules/iam_list_roles/variables.tf
@@ -1,3 +1,5 @@
-variable "org_name" {}
+variable "org_name" {
+}
 
-variable "system_name" {}
+variable "system_name" {
+}

--- a/infra/terraform/global/modules/iam_list_roles/versions.tf
+++ b/infra/terraform/global/modules/iam_list_roles/versions.tf
@@ -1,3 +1,4 @@
+
 terraform {
   required_version = ">= 0.12"
 }

--- a/infra/terraform/global/modules/lambda_mgmt/cloudwatch.tf
+++ b/infra/terraform/global/modules/lambda_mgmt/cloudwatch.tf
@@ -1,14 +1,18 @@
 # CloudWatch event rule to schedule event
 resource "aws_cloudwatch_event_rule" "lambda_cloud_watch_rule" {
-  name                = "${var.lambda_function_name}"
-  schedule_expression = "${var.schedule_expression}"
-  count               = "${var.enabled}"
+  name                = var.lambda_function_name
+  schedule_expression = var.schedule_expression
+  count               = local.enabled
 }
 
 # CloudWatch event target to set rule target to lambda function
 resource "aws_cloudwatch_event_target" "lambda_cloud_watch_target" {
-  target_id = "${var.lambda_function_name}"
-  arn       = "${aws_lambda_function.lambda_function.arn}"
-  rule      = "${aws_cloudwatch_event_rule.lambda_cloud_watch_rule.name}"
-  count     = "${var.enabled}"
+  target_id = var.lambda_function_name
+  arn       = aws_lambda_function.lambda_function[0].arn
+  rule      = aws_cloudwatch_event_rule.lambda_cloud_watch_rule[0].name
+  count     = local.enabled
+}
+
+locals {
+    enabled = var.enabled ? 1 : 0
 }

--- a/infra/terraform/global/modules/lambda_mgmt/iam.tf
+++ b/infra/terraform/global/modules/lambda_mgmt/iam.tf
@@ -1,6 +1,6 @@
 # Assume role policy to allow lambda to assume role
 data "aws_iam_policy_document" "lambda_snapshot_assume" {
-  "statement" {
+  statement {
     actions = ["sts:AssumeRole"]
 
     principals {
@@ -12,17 +12,17 @@ data "aws_iam_policy_document" "lambda_snapshot_assume" {
 
 # Lambda policy to attach to lambda_role
 resource "aws_iam_policy" "lambda_policy" {
-  policy = "${var.lamda_policy}"
+  policy = var.lamda_policy
 }
 
 # The role which the lambda service will assume
 resource "aws_iam_role" "lambda_role" {
-  name               = "${var.lambda_function_name}"
-  assume_role_policy = "${data.aws_iam_policy_document.lambda_snapshot_assume.json}"
+  name               = var.lambda_function_name
+  assume_role_policy = data.aws_iam_policy_document.lambda_snapshot_assume.json
 }
 
 # Attaching the lambda_policy to ebs_create_snapshot role
 resource "aws_iam_role_policy_attachment" "lambda_snapshot_attatchment" {
-  policy_arn = "${aws_iam_policy.lambda_policy.arn}"
-  role       = "${aws_iam_role.lambda_role.name}"
+  policy_arn = aws_iam_policy.lambda_policy.arn
+  role       = aws_iam_role.lambda_role.name
 }

--- a/infra/terraform/global/modules/lambda_mgmt/lambda.tf
+++ b/infra/terraform/global/modules/lambda_mgmt/lambda.tf
@@ -1,25 +1,25 @@
 # Create the Lambda function with environment variables for filtering or config
 resource "aws_lambda_function" "lambda_function" {
-  function_name    = "${var.lambda_function_name}"
-  filename         = "${var.zipfile}"
-  handler          = "${var.handler}"
-  role             = "${aws_iam_role.lambda_role.arn}"
-  runtime          = "${var.lambda_runtime}"
-  source_code_hash = "${var.source_code_hash}"
-  count            = "${var.enabled}"
-  timeout          = "${var.timeout}"
+  function_name    = var.lambda_function_name
+  filename         = var.zipfile
+  handler          = var.handler
+  role             = aws_iam_role.lambda_role.arn
+  runtime          = var.lambda_runtime
+  source_code_hash = var.source_code_hash
+  count            = local.enabled
+  timeout          = var.timeout
 
   environment {
-    variables = "${var.environment_variables}"
+    variables = var.environment_variables
   }
 }
 
 # Lambda permission to allow cloudwatch to invoke lambda function
 resource "aws_lambda_permission" "lambda_permission" {
+  count         = local.enabled
   action        = "lambda:InvokeFunction"
-  function_name = "${aws_lambda_function.lambda_function.function_name}"
+  function_name = aws_lambda_function.lambda_function[0].function_name
   principal     = "events.amazonaws.com"
   statement_id  = "AllowExecutionFromCloudWatch"
-  count         = "${var.enabled}"
-  source_arn    = "${aws_cloudwatch_event_rule.lambda_cloud_watch_rule.arn}"
+  source_arn    = aws_cloudwatch_event_rule.lambda_cloud_watch_rule[0].arn
 }

--- a/infra/terraform/global/modules/lambda_mgmt/variables.tf
+++ b/infra/terraform/global/modules/lambda_mgmt/variables.tf
@@ -17,6 +17,7 @@ variable "zipfile" {
 
 variable "enabled" {
   default = true
+  type    = bool
 }
 
 variable "timeout" {
@@ -27,14 +28,15 @@ variable "schedule_expression" {
   default = "rate(1 day)"
 }
 
-variable "source_code_hash" {}
+variable "source_code_hash" {
+}
 
 variable "lamda_policy" {
   description = "The IAM policy document.  Usually JSON"
 }
 
 variable "environment_variables" {
-  type        = "map"
+  type        = map(string)
   default     = {}
   description = "The environment variables for you lambda function"
 }

--- a/infra/terraform/global/modules/lambda_mgmt/versions.tf
+++ b/infra/terraform/global/modules/lambda_mgmt/versions.tf
@@ -1,3 +1,4 @@
+
 terraform {
   required_version = ">= 0.12"
 }

--- a/infra/terraform/global/modules/ses_domain/main.tf
+++ b/infra/terraform/global/modules/ses_domain/main.tf
@@ -1,37 +1,38 @@
 resource "aws_ses_domain_identity" "domain" {
-  domain = "${var.domain}"
+  domain = var.domain
 }
 
 # SES Verification: TXT Record
 resource "aws_route53_record" "amazonses_verification_record" {
-  zone_id = "${var.aws_route53_zone_id}"
-
-  name = "_amazonses.${aws_ses_domain_identity.domain.id}"
-
-  type = "TXT"
-  ttl  = "1800"
-
-  records = [
-    "${aws_ses_domain_identity.domain.verification_token}",
-  ]
+  zone_id = var.aws_route53_zone_id
+  name    = "_amazonses.${aws_ses_domain_identity.domain.id}"
+  type    = "TXT"
+  ttl     = "1800"
+  records = [aws_ses_domain_identity.domain.verification_token]
 }
 
 resource "aws_ses_domain_identity_verification" "amazonses_verification" {
-  domain = "${aws_ses_domain_identity.domain.id}"
+  domain = aws_ses_domain_identity.domain.id
 
-  depends_on = ["aws_route53_record.amazonses_verification_record"]
+  depends_on = [aws_route53_record.amazonses_verification_record]
 }
 
 # SES Verification: DKIM
 resource "aws_ses_domain_dkim" "domain_verification" {
-  domain = "${aws_ses_domain_identity.domain.domain}"
+  domain = aws_ses_domain_identity.domain.domain
 }
 
 resource "aws_route53_record" "domain_amazonses_dkim_verification_record" {
-  count   = "${length(aws_ses_domain_dkim.domain_verification.dkim_tokens)}"
-  zone_id = "${var.aws_route53_zone_id}"
-  name    = "${element(aws_ses_domain_dkim.domain_verification.dkim_tokens, count.index)}._domainkey.${aws_ses_domain_identity.domain.domain}"
-  type    = "CNAME"
-  ttl     = "1800"
-  records = ["${element(aws_ses_domain_dkim.domain_verification.dkim_tokens, count.index)}.dkim.amazonses.com"]
+  count   = length(aws_ses_domain_dkim.domain_verification.dkim_tokens)
+  zone_id = var.aws_route53_zone_id
+  name = "${element(
+    aws_ses_domain_dkim.domain_verification.dkim_tokens,
+    count.index,
+  )}._domainkey.${aws_ses_domain_identity.domain.domain}"
+  type = "CNAME"
+  ttl  = "1800"
+  records = ["${element(
+    aws_ses_domain_dkim.domain_verification.dkim_tokens,
+    count.index,
+  )}.dkim.amazonses.com"]
 }

--- a/infra/terraform/global/modules/ses_domain/outputs.tf
+++ b/infra/terraform/global/modules/ses_domain/outputs.tf
@@ -1,3 +1,3 @@
 output "identity_arn" {
-  value = "${aws_ses_domain_identity.domain.arn}"
+  value = aws_ses_domain_identity.domain.arn
 }

--- a/infra/terraform/global/modules/ses_domain/variables.tf
+++ b/infra/terraform/global/modules/ses_domain/variables.tf
@@ -1,3 +1,6 @@
-variable "domain" {}
+variable "domain" {
+}
 
-variable "aws_route53_zone_id" {}
+variable "aws_route53_zone_id" {
+}
+

--- a/infra/terraform/global/modules/ses_domain/versions.tf
+++ b/infra/terraform/global/modules/ses_domain/versions.tf
@@ -1,3 +1,4 @@
+
 terraform {
   required_version = ">= 0.12"
 }

--- a/infra/terraform/global/outputs.tf
+++ b/infra/terraform/global/outputs.tf
@@ -1,63 +1,63 @@
 output "region" {
-  value = "${var.region}"
+  value = var.region
 }
 
 output "platform_dns_zone_id" {
-  value = "${aws_route53_zone.platform_zone.id}"
+  value = aws_route53_zone.platform_zone.id
 }
 
 output "platform_dns_zone_name" {
-  value = "${aws_route53_zone.platform_zone.name}"
+  value = aws_route53_zone.platform_zone.name
 }
 
 output "platform_root_domain" {
-  value = "${var.platform_root_domain}"
+  value = var.platform_root_domain
 }
 
 output "platform_root_domain_ses_identity_arn" {
-  value = "${module.ses_domain.identity_arn}"
+  value = module.ses_domain.identity_arn
 }
 
 output "kops_bucket_name" {
-  value = "${var.kops_bucket_name}"
+  value = var.kops_bucket_name
 }
 
 output "kops_bucket_arn" {
-  value = "${aws_s3_bucket.kops_state.arn}"
+  value = aws_s3_bucket.kops_state.arn
 }
 
 output "kops_bucket_id" {
-  value = "${aws_s3_bucket.kops_state.id}"
+  value = aws_s3_bucket.kops_state.id
 }
 
 output "auth0_ses_access_key_id" {
-  value = "${aws_iam_access_key.auth0_ses.id}"
+  value = aws_iam_access_key.auth0_ses.id
 }
 
 output "auth0_ses_secret_key" {
-  value = "${aws_iam_access_key.auth0_ses.secret}"
+  value = aws_iam_access_key.auth0_ses.secret
 }
 
 output "softnas_iam_role_arn" {
-  value = "${aws_iam_role.softnas.arn}"
+  value = aws_iam_role.softnas.arn
 }
 
 output "s3_logs_bucket_name" {
-  value = "${module.aws_account_logging.s3_logs_bucket_name}"
+  value = module.aws_account_logging.s3_logs_bucket_name
 }
 
 output "mojanalytics_concourse_iam_list_roles_access_key_id" {
-  value = "${module.mojanalytics_concourse_iam_list_roles_user.access_key_id}"
+  value = module.mojanalytics_concourse_iam_list_roles_user.access_key_id
 }
 
 output "mojanalytics_concourse_iam_list_roles_access_key_secret" {
-  value = "${module.mojanalytics_concourse_iam_list_roles_user.access_key_secret}"
+  value = module.mojanalytics_concourse_iam_list_roles_user.access_key_secret
 }
 
 output "concourse_update_helm_repo_access_key_id" {
-  value = "${aws_iam_access_key.concourse_update_helm_repo_access_key.id}"
+  value = aws_iam_access_key.concourse_update_helm_repo_access_key.id
 }
 
 output "concourse_update_helm_repo_access_key_secret" {
-  value = "${aws_iam_access_key.concourse_update_helm_repo_access_key.secret}"
+  value = aws_iam_access_key.concourse_update_helm_repo_access_key.secret
 }

--- a/infra/terraform/global/s3.tf
+++ b/infra/terraform/global/s3.tf
@@ -1,6 +1,6 @@
 resource "aws_s3_bucket" "kops_state" {
-  bucket = "${var.kops_bucket_name}"
-  region = "${var.region}"
+  bucket = var.kops_bucket_name
+  region = var.region
   acl    = "private"
 
   versioning {

--- a/infra/terraform/global/variables.tf
+++ b/infra/terraform/global/variables.tf
@@ -2,12 +2,23 @@ variable "region" {
   default = "eu-west-1"
 }
 
-variable "kops_bucket_name" {}
-variable "platform_root_domain" {}
-variable "es_domain" {}
-variable "es_port" {}
-variable "es_username" {}
-variable "es_password" {}
+variable "kops_bucket_name" {
+}
+
+variable "platform_root_domain" {
+}
+
+variable "es_domain" {
+}
+
+variable "es_port" {
+}
+
+variable "es_username" {
+}
+
+variable "es_password" {
+}
 
 variable "es_scheme" {
   default = "https"
@@ -46,10 +57,11 @@ variable "vpcflowlogs_s3_bucket_name" {
   default = "moj-analytics-global-vpcflowlogs"
 }
 
-variable "vpc_id" {}
+variable "vpc_id" {
+}
 
 variable "environment_variables" {
-  type        = "map"
+  type        = map(string)
   description = "Empty Placeholder variable to be overrided when using the lambda_mgmt module"
   default     = {}
 }


### PR DESCRIPTION
All files in the global folder have been upgraded to use the newer Terraform 0.12 syntax.

The upgrade was performed using the `terraform 0.12upgrade` command and manual approval. 

There are some minor changes in the lambdas where the source code hashes
have changed. This is expected withthe current implmenetation of the
modules.

See below for the plan. 

<details><summary>terraform plan</summary>
<p>

```shell
An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  ~ update in-place
-/+ destroy and then create replacement
 <= read (data resources)

Terraform will perform the following actions:

  # module.aws_account_logging.data.archive_file.cloudtrail_zip will be read during apply
  # (config refers to values not yet known)
 <= data "archive_file" "cloudtrail_zip"  {
      + id                  = (known after apply)
      + output_base64sha256 = (known after apply)
      + output_md5          = (known after apply)
      + output_path         = "/tmp/cloudtrail.zip"
      + output_sha          = (known after apply)
      + output_size         = (known after apply)
      + source_dir          = "modules/aws_account_logging/cloudtrail"
      + type                = "zip"
    }

  # module.aws_account_logging.data.archive_file.s3logs_zip will be read during apply
  # (config refers to values not yet known)
 <= data "archive_file" "s3logs_zip"  {
      + id                  = (known after apply)
      + output_base64sha256 = (known after apply)
      + output_md5          = (known after apply)
      + output_path         = "/tmp/s3logs.zip"
      + output_sha          = (known after apply)
      + output_size         = (known after apply)
      + source_dir          = "modules/aws_account_logging/s3logs"
      + type                = "zip"
    }

  # module.aws_account_logging.aws_lambda_function.cloudtrail_to_elasticsearch will be updated in-place
  ~ resource "aws_lambda_function" "cloudtrail_to_elasticsearch" {
        arn                            = "arn:aws:lambda:eu-west-1:593291632749:function:cloudtrail_to_elasticsearch"
        description                    = "Ships Cloudtrail logs to Elasticsearch"
        filename                       = "/tmp/cloudtrail.zip"
        function_name                  = "cloudtrail_to_elasticsearch"
        handler                        = "cloudtrail_to_es.lambda_handler"
        id                             = "cloudtrail_to_elasticsearch"
        invoke_arn                     = "arn:aws:apigateway:eu-west-1:lambda:path/2015-03-31/functions/arn:aws:lambda:eu-west-1:593291632749:function:cloudtrail_to_elasticsearch/invocations"
      ~ last_modified                  = "2020-09-08T13:51:54.469+0000" -> (known after apply)
        layers                         = []
        memory_size                    = 128
        publish                        = false
        qualified_arn                  = "arn:aws:lambda:eu-west-1:593291632749:function:cloudtrail_to_elasticsearch:$LATEST"
        reserved_concurrent_executions = -1
        role                           = "arn:aws:iam::593291632749:role/cloudtrail_to_elasticsearch"
        runtime                        = "python3.6"
      ~ source_code_hash               = "zSCvWcHCFYYv5fw3Oed5Vk01Psz36Vds36m28N9MKwc=" -> (known after apply)
        source_code_size               = 596295
        tags                           = {}
        timeout                        = 30
        version                        = "$LATEST"

        environment {
            variables = {
                "ES_DOMAIN"   = "f58ddb963b371b72f957e6cd3660f350.eu-west-1.aws.found.io"
                "ES_PASSWORD" = "kAPD4zwPb38aUTdjOqiyEZAE"
                "ES_PORT"     = "9243"
                "ES_SCHEME"   = "https"
                "ES_USERNAME" = "elastic"
            }
        }

        timeouts {}

        tracing_config {
            mode = "PassThrough"
        }
    }

  # module.aws_account_logging.aws_lambda_function.s3_logs_to_elasticsearch will be updated in-place
  ~ resource "aws_lambda_function" "s3_logs_to_elasticsearch" {
        arn                            = "arn:aws:lambda:eu-west-1:593291632749:function:s3_logs_to_elasticsearch"
        description                    = "Ships s3 access logs to Elasticsearch"
        filename                       = "/tmp/s3logs.zip"
        function_name                  = "s3_logs_to_elasticsearch"
        handler                        = "s3_to_es.lambda_handler"
        id                             = "s3_logs_to_elasticsearch"
        invoke_arn                     = "arn:aws:apigateway:eu-west-1:lambda:path/2015-03-31/functions/arn:aws:lambda:eu-west-1:593291632749:function:s3_logs_to_elasticsearch/invocations"
      ~ last_modified                  = "2020-09-08T13:55:32.631+0000" -> (known after apply)
        layers                         = []
        memory_size                    = 128
        publish                        = false
        qualified_arn                  = "arn:aws:lambda:eu-west-1:593291632749:function:s3_logs_to_elasticsearch:$LATEST"
        reserved_concurrent_executions = -1
        role                           = "arn:aws:iam::593291632749:role/s3_logs_to_elasticsearch"
        runtime                        = "python3.6"
      ~ source_code_hash               = "iTQa7uf8NF1ysujn+YOCU+IyKsZmoOepYmdHNF82lMs=" -> (known after apply)
        source_code_size               = 1015795
        tags                           = {}
        timeout                        = 5
        version                        = "$LATEST"

        environment {
            variables = {
                "ES_DOMAIN"   = "f58ddb963b371b72f957e6cd3660f350.eu-west-1.aws.found.io"
                "ES_PASSWORD" = "kAPD4zwPb38aUTdjOqiyEZAE"
                "ES_PORT"     = "9243"
                "ES_SCHEME"   = "https"
                "ES_USERNAME" = "elastic"
            }
        }

        timeouts {}

        tracing_config {
            mode = "PassThrough"
        }
    }

  # module.aws_account_logging.aws_lambda_function.vpcflowlogs_to_elasticsearch will be updated in-place
  ~ resource "aws_lambda_function" "vpcflowlogs_to_elasticsearch" {
        arn                            = "arn:aws:lambda:eu-west-1:593291632749:function:vpcflowlogs_to_elasticsearch"
        filename                       = "/tmp/vpcflowlogs.zip"
        function_name                  = "vpcflowlogs_to_elasticsearch"
        handler                        = "vpcflowlogs_to_elasticsearch.lambda_handler"
        id                             = "vpcflowlogs_to_elasticsearch"
        invoke_arn                     = "arn:aws:apigateway:eu-west-1:lambda:path/2015-03-31/functions/arn:aws:lambda:eu-west-1:593291632749:function:vpcflowlogs_to_elasticsearch/invocations"
      ~ last_modified                  = "2020-09-08T13:55:30.958+0000" -> (known after apply)
        layers                         = []
        memory_size                    = 128
        publish                        = false
        qualified_arn                  = "arn:aws:lambda:eu-west-1:593291632749:function:vpcflowlogs_to_elasticsearch:$LATEST"
        reserved_concurrent_executions = -1
        role                           = "arn:aws:iam::593291632749:role/vpcflowlogs_to_elasticsearch"
        runtime                        = "python3.6"
      ~ source_code_hash               = "oacwk6lCkSJ9JTM1L6Uiu0ugLMaUxew3Zzh+f3WJOKE=" -> "JPW77K8kAi+DBKbOO0dWFM170fGUMEOdJjrEKbzilBY="
        source_code_size               = 9778354
        tags                           = {}
        timeout                        = 30
        version                        = "$LATEST"

        environment {
            variables = {
                "ES_DOMAIN"   = "f58ddb963b371b72f957e6cd3660f350.eu-west-1.aws.found.io"
                "ES_PASSWORD" = "kAPD4zwPb38aUTdjOqiyEZAE"
                "ES_PORT"     = "9243"
                "ES_SCHEME"   = "https"
                "ES_USERNAME" = "elastic"
            }
        }

        timeouts {}

        tracing_config {
            mode = "PassThrough"
        }
    }

  # module.aws_account_logging.null_resource.cloudtrail_install_deps must be replaced
-/+ resource "null_resource" "cloudtrail_install_deps" {
      ~ id       = "6534559863060079763" -> (known after apply)
      + triggers = (known after apply) # forces replacement
    }

  # module.aws_account_logging.null_resource.s3logs_install_deps must be replaced
-/+ resource "null_resource" "s3logs_install_deps" {
      ~ id       = "8225546461971726865" -> (known after apply)
      + triggers = (known after apply) # forces replacement
    }

  # module.aws_account_logging.null_resource.vpcflowlogs_install_deps must be replaced
-/+ resource "null_resource" "vpcflowlogs_install_deps" {
      ~ id       = "6845164438476661208" -> (known after apply)
      + triggers = (known after apply) # forces replacement
    }

  # module.kubernetes_etcd_ebs_snapshot.aws_lambda_function.lambda_function[0] will be updated in-place
  ~ resource "aws_lambda_function" "lambda_function" {
        arn                            = "arn:aws:lambda:eu-west-1:593291632749:function:create_etcd_ebs_snapshot"
        filename                       = "assets/create_etcd_ebs_snapshot/create_etcd_ebs_snapshot.zip"
        function_name                  = "create_etcd_ebs_snapshot"
        handler                        = "create_etcd_ebs_snapshot"
        id                             = "create_etcd_ebs_snapshot"
        invoke_arn                     = "arn:aws:apigateway:eu-west-1:lambda:path/2015-03-31/functions/arn:aws:lambda:eu-west-1:593291632749:function:create_etcd_ebs_snapshot/invocations"
      ~ last_modified                  = "2019-06-07T09:14:52.847+0000" -> (known after apply)
        layers                         = []
        memory_size                    = 128
        publish                        = false
        qualified_arn                  = "arn:aws:lambda:eu-west-1:593291632749:function:create_etcd_ebs_snapshot:$LATEST"
        reserved_concurrent_executions = -1
        role                           = "arn:aws:iam::593291632749:role/create_etcd_ebs_snapshot"
        runtime                        = "go1.x"
      ~ source_code_hash               = "/sPD7hXrgqGRhFpxPWK88iSspbohU+5Do8NlPC8KJa4=" -> "g6kErAbI0iZkvnKM5oYlzA/kVF81lCCeMM37QNJSy30="
        source_code_size               = 3967484
        tags                           = {}
        timeout                        = 3
        version                        = "$LATEST"

        environment {
            variables = {
                "INSTANCE_TAG_KEY"   = "k8s.io/role/master"
                "INSTANCE_TAG_VALUE" = "1"
                "TAG_KEY"            = "etcd"
                "TAG_VALUE"          = "1"
            }
        }

        timeouts {}

        tracing_config {
            mode = "PassThrough"
        }
    }

  # module.kubernetes_prune_ebs_snapshots.aws_lambda_function.lambda_function[0] will be updated in-place
  ~ resource "aws_lambda_function" "lambda_function" {
        arn                            = "arn:aws:lambda:eu-west-1:593291632749:function:prune_ebs_snapshots"
        filename                       = "assets/prune_ebs_snapshots/prune_ebs_snapshots.zip"
        function_name                  = "prune_ebs_snapshots"
        handler                        = "prune_ebs_snapshots"
        id                             = "prune_ebs_snapshots"
        invoke_arn                     = "arn:aws:apigateway:eu-west-1:lambda:path/2015-03-31/functions/arn:aws:lambda:eu-west-1:593291632749:function:prune_ebs_snapshots/invocations"
      ~ last_modified                  = "2019-06-07T10:28:38.990+0000" -> (known after apply)
        layers                         = []
        memory_size                    = 128
        publish                        = false
        qualified_arn                  = "arn:aws:lambda:eu-west-1:593291632749:function:prune_ebs_snapshots:$LATEST"
        reserved_concurrent_executions = -1
        role                           = "arn:aws:iam::593291632749:role/prune_ebs_snapshots"
        runtime                        = "go1.x"
      ~ source_code_hash               = "XbciQ2gv0B2pGxu1t4iwRbyHjemfzQRmCBlXm/Xz+8w=" -> "+/ZBrgVRhLB0Rvm4sPadI/70nFNb/fs8tVdKAZABDfM="
        source_code_size               = 3942739
        tags                           = {}
        timeout                        = 3
        version                        = "$LATEST"

        environment {
            variables = {
                "DAYS_OLD"           = "14"
                "SNAPSHOT_TAG_KEY"   = "etcd"
                "SNAPSHOT_TAG_VALUE" = "1"
            }
        }

        timeouts {}

        tracing_config {
            mode = "PassThrough"
        }
    }

Plan: 3 to add, 5 to change, 3 to destroy.

------------------------------------------------------------------------

Note: You didn't specify an "-out" parameter to save this plan, so Terraform
can't guarantee that exactly these actions will be performed if
"terraform apply" is subsequently run.

```
<p/>
</details>