### PR TITLE
Add tags to resources & tidy up the lambda_mgmt module

### DIFF
--- a/infra/terraform/global/cloudtrail.tf
+++ b/infra/terraform/global/cloudtrail.tf
@@ -1,6 +1,7 @@
 resource "aws_kms_key" "cloudtrail" {
   description = "Cloudtrail S3 bucket KMS key"
   policy      = data.aws_iam_policy_document.cloudtrail.json
+  tags        = local.tags
 }
 
 data "aws_iam_policy_document" "cloudtrail" {
@@ -130,12 +131,14 @@ resource "aws_cloudtrail" "global" {
   is_multi_region_trail      = true
   enable_log_file_validation = true
   kms_key_id                 = aws_kms_key.cloudtrail.arn
+  tags                       = local.tags
 }
 
 resource "aws_s3_bucket" "global_cloudtrail" {
   bucket        = var.global_cloudtrail_bucket_name
   force_destroy = false
   policy        = data.aws_iam_policy_document.global_cloudtrail.json
+  tags          = local.tags
 
   lifecycle_rule {
     id                                     = "logs-transition"

--- a/infra/terraform/global/dns.tf
+++ b/infra/terraform/global/dns.tf
@@ -12,11 +12,5 @@ resource "aws_route53_record" "global_ns" {
   name    = aws_route53_zone.global.name
   type    = "NS"
   ttl     = "30"
-
-  records = [
-    aws_route53_zone.global.name_servers[0],
-    aws_route53_zone.global.name_servers[1],
-    aws_route53_zone.global.name_servers[2],
-    aws_route53_zone.global.name_servers[3],
-  ]
+  records = aws_route53_zone.global.name_servers
 }

--- a/infra/terraform/global/dynamodb.tf
+++ b/infra/terraform/global/dynamodb.tf
@@ -3,6 +3,7 @@ resource "aws_dynamodb_table" "terraform-lock-platform-base" {
   hash_key       = "LockID"
   read_capacity  = 5
   write_capacity = 5
+  tags           = local.tags
 
   server_side_encryption {
     enabled = true
@@ -19,6 +20,7 @@ resource "aws_dynamodb_table" "terraform-lock-platform" {
   hash_key       = "LockID"
   read_capacity  = 5
   write_capacity = 5
+  tags           = local.tags
 
   server_side_encryption {
     enabled = true

--- a/infra/terraform/global/ebs_snapshots.tf
+++ b/infra/terraform/global/ebs_snapshots.tf
@@ -22,6 +22,7 @@ module "kubernetes_etcd_ebs_snapshot" {
   source_code_hash      = data.archive_file.kubernetes_etcd_ebs_snapshot_code.output_base64sha256
   lamda_policy          = data.template_file.lambda_create_snapshot_policy.rendered
   environment_variables = var.create_etcd_ebs_snapshot_env_vars
+  tags                  = local.tags
 }
 
 // Prune snapshots -->
@@ -45,5 +46,6 @@ module "kubernetes_prune_ebs_snapshots" {
   source_code_hash      = data.archive_file.kubernetes_prune_ebs_snapshots_code.output_base64sha256
   lamda_policy          = data.template_file.lambda_prune_ebs_snapshots_policy.rendered
   environment_variables = var.prune_etcd_ebs_snapshot_env_vars
+  tags                  = local.tags
 }
 

--- a/infra/terraform/global/main.tf
+++ b/infra/terraform/global/main.tf
@@ -34,17 +34,27 @@ module "aws_account_logging" {
   vpcflowlogs_s3_bucket_name = var.vpcflowlogs_s3_bucket_name
 
   vpc_id = var.vpc_id
+  tags   = local.tags
 }
 
 module "mojanalytics_concourse_iam_list_roles_user" {
   source      = "./modules/iam_list_roles"
   org_name    = "mojanalytics"
   system_name = "concourse"
+  tags        = local.tags
 }
 
 module "ses_domain" {
-  source = "./modules/ses_domain"
-  domain = var.platform_root_domain
-
+  source              = "./modules/ses_domain"
+  domain              = var.platform_root_domain
   aws_route53_zone_id = aws_route53_zone.platform_zone.zone_id
+}
+
+locals {
+  tags = {
+    business-unit = "Platforms"
+    application   = "analytical-platform"
+    owner         = "analytical-platform:analytics-platform-tech@digital.justice.gov.uk"
+    is-production = "true"
+  }
 }

--- a/infra/terraform/global/main.tf
+++ b/infra/terraform/global/main.tf
@@ -52,9 +52,10 @@ module "ses_domain" {
 
 locals {
   tags = {
-    business-unit = "Platforms"
-    application   = "analytical-platform"
-    owner         = "analytical-platform:analytics-platform-tech@digital.justice.gov.uk"
-    is-production = "true"
+    business-unit  = "Platforms"
+    application    = "analytical-platform"
+    owner          = "analytical-platform:analytics-platform-tech@digital.justice.gov.uk"
+    is-production  = "true"
+    git-repository = "https://github.com/ministryofjustice/analytics-platform-ops"
   }
 }

--- a/infra/terraform/global/modules/aws_account_logging/s3.tf
+++ b/infra/terraform/global/modules/aws_account_logging/s3.tf
@@ -23,9 +23,11 @@ resource "aws_s3_bucket" "s3_logs" {
     }
   }
 
-  tags = {
-    Name = "moj-analytics-s3-logs"
-  }
+  tags = merge(
+    var.tags,
+    { Name = "moj-analytics-s3-logs" }
+  )
+
 
   server_side_encryption_configuration {
     rule {

--- a/infra/terraform/global/modules/aws_account_logging/variables.tf
+++ b/infra/terraform/global/modules/aws_account_logging/variables.tf
@@ -1,33 +1,49 @@
 variable "es_domain" {
+  type = string
 }
 
 variable "es_port" {
+  type = string
 }
 
 variable "es_username" {
+  type = string
 }
 
 variable "es_password" {
+  type = string
 }
 
 variable "es_scheme" {
+  type    = string
   default = "https"
 }
 
 variable "cloudtrail_s3_bucket_id" {
+  type = string
 }
 
 variable "cloudtrail_s3_bucket_arn" {
+  type = string
 }
 
 variable "account_id" {
+  type = string
 }
 
 variable "s3_logs_bucket_name" {
+  type = string
 }
 
 variable "vpcflowlogs_s3_bucket_name" {
+  type = string
 }
 
 variable "vpc_id" {
+  type = string
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "A map of tags to apply to resources"
 }

--- a/infra/terraform/global/modules/iam_list_roles/iam.tf
+++ b/infra/terraform/global/modules/iam_list_roles/iam.tf
@@ -1,6 +1,7 @@
 resource "aws_iam_user" "system" {
   name = "${var.org_name}_${var.system_name}_iam_roles_readonly"
   path = "/uploaders/${var.org_name}/"
+  tags = var.tags
 }
 
 resource "aws_iam_access_key" "system_user" {
@@ -9,15 +10,9 @@ resource "aws_iam_access_key" "system_user" {
 
 data "aws_iam_policy_document" "iam_roles_readonly" {
   statement {
-    actions = [
-      "iam:ListRoles",
-    ]
-
-    effect = "Allow"
-
-    resources = [
-      "*",
-    ]
+    actions   = ["iam:ListRoles"]
+    effect    = "Allow"
+    resources = ["*"]
   }
 }
 

--- a/infra/terraform/global/modules/iam_list_roles/variables.tf
+++ b/infra/terraform/global/modules/iam_list_roles/variables.tf
@@ -1,5 +1,13 @@
 variable "org_name" {
+  type        = string
+  description = "Organisation name"
 }
 
 variable "system_name" {
+  type        = string
+  description = "System name"
+}
+
+variable "tags" {
+  type = map(string)
 }

--- a/infra/terraform/global/modules/lambda_mgmt/CHANGELOG.md
+++ b/infra/terraform/global/modules/lambda_mgmt/CHANGELOG.md
@@ -1,9 +1,0 @@
-# Changelog
-All notable changes to this project will be documented in this file.
-
-The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
-and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
-
-## [0.1.0] - 2018-05-16
-### Lambda Management Module
-- Initial Commit

--- a/infra/terraform/global/modules/lambda_mgmt/README.md
+++ b/infra/terraform/global/modules/lambda_mgmt/README.md
@@ -1,28 +1,43 @@
-## Lambda Management 
-====================
+# Lambda Management
 
 Used to provision lambda functions
 
-Module Input Variables
-----------------------
+## Requirements
 
-- `lambda_function_name` - Name for Lambda function
-- `lambda_runtime` - A [valid](http://docs.aws.amazon.com/cli/latest/reference/lambda/create-function.html#options) Lambda runtime environment. Defaults to `go1.x`
-- `zipfile` - Path to zip archive containing Lambda function
-- `handler` - The entrypoint into your Lambda function, in the form of `filename.function_name`. For `Golang` this must match `lambda_function_name`
-- `schedule_expression` - A [valid rate or cron expression](http://docs.aws.amazon.com/lambda/latest/dg/tutorial-scheduled-events-schedule-expressions.html)
-- `source_code_hash` - The base64 encoded sha256 hash of the archive file - see TF [archive file provider](https://www.terraform.io/docs/providers/archive/d/archive_file.html)
-- `timeout` - (optional) The amount of time your Lambda Function has to run in seconds. Defaults to 3. See [Limits](https://docs.aws.amazon.com/lambda/latest/dg/limits.html)
-- `enabled` - (optional) Boolean expression. If false, the lambda function and the cloudwatch schedule are not set. Defaults to `true`.
-- `environment_variables` - (optional) The environment variables to set for your lambda function
-- `lambda_policy` - The IAM policy document.  Usually JSON 
+| Name      | Version |
+| --------- | ------- |
+| terraform | >= 0.12 |
 
-Usage 
------
+## Providers
 
-The example below provisions a lambda function that manages ebs snapshots
+| Name | Version |
+| ---- | ------- |
+| aws  | n/a     |
 
-```
+## Inputs
+
+| Name                   | Description                                                                                                                            | Type          | Default         | Required |
+| ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------- | ------------- | --------------- | :------: |
+| enabled                | (optional) Boolean expression. If false, the lambda function and the cloudwatch schedule are not set.                                  | `bool`        | `true`          |    no    |
+| environment\_variables | (optional) The environment variables for you lambda function                                                                           | `map(string)` | `{}`            |    no    |
+| handler                | The entrypoint into your Lambda function, in the form of `filename.function_name`. For `Golang` this must match `lambda_function_name` | `string`      | n/a             |   yes    |
+| lambda\_function\_name | The default name of all resources                                                                                                      | `string`      | n/a             |   yes    |
+| lambda\_runtime        | Runtime language for lambda function.                                                                                                  | `string`      | `"go1.x"`       |    no    |
+| lamda\_policy          | The IAM policy document to attach to the lambda                                                                                        | `string`      | n/a             |   yes    |
+| schedule\_expression   | A valid rate or cron expression                                                                                                        | `string`      | `"rate(1 day)"` |    no    |
+| source\_code\_hash     | The base64 encoded sha256 hash of the archive file                                                                                     | `string`      | n/a             |   yes    |
+| timeout                | (optional) The amount of time your Lambda Function has to run in seconds. Defaults to 3                                                | `number`      | `3`             |    no    |
+| zipfile                | Path to zip file containing code                                                                                                       | `string`      | n/a             |   yes    |
+
+## Outputs
+
+No output
+
+## Usage
+
+The example below provisions a lambda function that manages EBS snapshots
+
+```hcl
 variable "environment_variables" {
   type = "map"
 
@@ -35,7 +50,7 @@ variable "environment_variables" {
 }
 
 data "template_file" "lambda_create_snapshot_policy" {
-  template = "${file("assets/create_etcd_ebs_snapshot/lambda_create_snapshot_policy.json")}"
+  template = file("assets/create_etcd_ebs_snapshot/lambda_create_snapshot_policy.json")
 }
 
 data "archive_file" "kubernetes_etcd_ebs_snapshot_code" {
@@ -49,21 +64,8 @@ module "kubernetes_etcd_ebs_snapshot" {
   lambda_function_name  = "create_etcd_ebs_snapshot"
   zipfile               = "assets/create_etcd_ebs_snapshot/create_etcd_ebs_snapshot.zip"
   handler               = "create_etcd_ebs_snapshot"
-  source_code_hash      = "${data.archive_file.kubernetes_etcd_ebs_snapshot_code.output_base64sha256}"
-  lamda_policy          = "${data.template_file.lambda_create_snapshot_policy.rendered}"
-  environment_variables = "${var.environment_variables}"
+  source_code_hash      = data.archive_file.kubernetes_etcd_ebs_snapshot_code.output_base64sha256
+  lamda_policy          = data.template_file.lambda_create_snapshot_policy.rendered
+  environment_variables = var.environment_variables
 }
 ```
-
-```
-terraform plan -target=module.kubernetes_etcd_ebs_snapshot
-
-
-terraform apply -target=module.kubernetes_etcd_ebs_snapshot
-
-```
-
-Outputs
--------
-
-None yet

--- a/infra/terraform/global/modules/lambda_mgmt/iam.tf
+++ b/infra/terraform/global/modules/lambda_mgmt/iam.tf
@@ -19,6 +19,7 @@ resource "aws_iam_policy" "lambda_policy" {
 resource "aws_iam_role" "lambda_role" {
   name               = var.lambda_function_name
   assume_role_policy = data.aws_iam_policy_document.lambda_snapshot_assume.json
+  tags               = var.tags
 }
 
 # Attaching the lambda_policy to ebs_create_snapshot role

--- a/infra/terraform/global/modules/lambda_mgmt/lambda.tf
+++ b/infra/terraform/global/modules/lambda_mgmt/lambda.tf
@@ -1,4 +1,3 @@
-# Create the Lambda function with environment variables for filtering or config
 resource "aws_lambda_function" "lambda_function" {
   function_name    = var.lambda_function_name
   filename         = var.zipfile
@@ -8,13 +7,13 @@ resource "aws_lambda_function" "lambda_function" {
   source_code_hash = var.source_code_hash
   count            = local.enabled
   timeout          = var.timeout
+  tags             = var.tags
 
   environment {
     variables = var.environment_variables
   }
 }
 
-# Lambda permission to allow cloudwatch to invoke lambda function
 resource "aws_lambda_permission" "lambda_permission" {
   count         = local.enabled
   action        = "lambda:InvokeFunction"

--- a/infra/terraform/global/modules/lambda_mgmt/variables.tf
+++ b/infra/terraform/global/modules/lambda_mgmt/variables.tf
@@ -1,42 +1,60 @@
 variable "lambda_function_name" {
+  type        = string
   description = "The default name of all resources"
 }
 
 variable "lambda_runtime" {
+  type        = string
   default     = "go1.x"
-  description = "Runtime language for lambda function. See: https://docs.aws.amazon.com/lambda/latest/dg/API_CreateFunction.html#SSS-CreateFunction-request-Runtime"
+  description = "Runtime language for lambda function."
 }
 
 variable "handler" {
-  description = "Entrypoint filename. For `Golang` this must match `lambda_function_name`"
+  type        = string
+  description = "The entrypoint into your Lambda function, in the form of `filename.function_name`. For `Golang` this must match `lambda_function_name`"
 }
 
 variable "zipfile" {
+  type        = string
   description = "Path to zip file containing code"
 }
 
 variable "enabled" {
-  default = true
-  type    = bool
+  type        = bool
+  default     = true
+  description = "(optional) Boolean expression. If false, the lambda function and the cloudwatch schedule are not set."
 }
 
 variable "timeout" {
-  default = 3
+  type        = number
+  default     = 3
+  description = "(optional) The amount of time your Lambda Function has to run in seconds. Defaults to 3"
 }
 
 variable "schedule_expression" {
-  default = "rate(1 day)"
+  type        = string
+  default     = "rate(1 day)"
+  description = "A valid rate or cron expression"
 }
 
 variable "source_code_hash" {
+  type        = string
+  description = "The base64 encoded sha256 hash of the archive file"
 }
 
 variable "lamda_policy" {
-  description = "The IAM policy document.  Usually JSON"
+  type        = string
+  description = "The IAM policy document to attach to the lambda"
 }
 
 variable "environment_variables" {
   type        = map(string)
   default     = {}
-  description = "The environment variables for you lambda function"
+  description = "(optional) The environment variables for you lambda function"
+
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "A map of tags to apply to resources"
 }

--- a/infra/terraform/global/modules/ses_domain/main.tf
+++ b/infra/terraform/global/modules/ses_domain/main.tf
@@ -12,8 +12,7 @@ resource "aws_route53_record" "amazonses_verification_record" {
 }
 
 resource "aws_ses_domain_identity_verification" "amazonses_verification" {
-  domain = aws_ses_domain_identity.domain.id
-
+  domain     = aws_ses_domain_identity.domain.id
   depends_on = [aws_route53_record.amazonses_verification_record]
 }
 

--- a/infra/terraform/global/modules/ses_domain/variables.tf
+++ b/infra/terraform/global/modules/ses_domain/variables.tf
@@ -1,6 +1,7 @@
 variable "domain" {
+  type = string
 }
 
 variable "aws_route53_zone_id" {
+  type = string
 }
-

--- a/infra/terraform/global/s3.tf
+++ b/infra/terraform/global/s3.tf
@@ -2,6 +2,7 @@ resource "aws_s3_bucket" "kops_state" {
   bucket = var.kops_bucket_name
   region = var.region
   acl    = "private"
+  tags   = local.tags
 
   versioning {
     enabled = true


### PR DESCRIPTION
## What

This PR;

- Adds the mandatory tags to all available resources
- Add descriptions to variables so `terraform-docs` can generate the table for the `lambda_mgmt` module correctly 
- Adds types to variables so variables don't just let anything through
- Uses Terraform 0.12 handling of arrays to pull back an array from `aws_route53_zone.global.name_servers` rather than specifying all the name servers in the array manually. This makes moving between name servers/ regions easier. 

