### PR TITLE
Delete CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @ministryofjustice/analytics-hq


### PR DESCRIPTION
We should invite reviewers manually, depending on who's relevant
