### PR TITLE
Upgrade Elasticsearch Terraform to 0.13

### DIFF
--- a/infra/elasticsearch/README.md
+++ b/infra/elasticsearch/README.md
@@ -1,25 +1,25 @@
-## Elasticsearch
+# Elasticsearch
 
 We use a hosted service provided by [elastic](https://www.elastic.co) which can be managed from the [console](https://cloud.elastic.co/#/authentication/login/)
 
-#### Administration
+## Administration
 
 The easiest way to administer elasticsearch itself is via the integrated __API Console__ which can be accessed once logged in to the [console](https://cloud.elastic.co/#/authentication/login/)
 
-#### Backups
+## Backups
 
 It is recommended to use the __analytics-logging-backups__ `iam` user when performing backup operations
 
 You'll need the __analytics-logging-backups__ `iam` user's access keys when working with the __s3__ backed repository
 
-##### Repository
+## Repository
 
-You'll need a repository to store snapshots.  For this we use an s3 backend
+You'll need a repository to store snapshots. For this we use an s3 backend
 
 From the __API Console__
 
-```
-PUT /_snapshot/repository 
+```json
+PUT /_snapshot/repository
 {
   "type": "s3",
   "settings": {
@@ -32,13 +32,13 @@ PUT /_snapshot/repository
 }
 ```
 
-##### Snapshot
+### Snapshot
 
 With an existing repository, you can now create snapshots
 
 From the __API Console__
 
-```
+```json
 PUT /_snapshot/repository/pre-upgrade-01-01-1970 {
 {
   "include_global_state": "false",
@@ -47,14 +47,14 @@ PUT /_snapshot/repository/pre-upgrade-01-01-1970 {
 }
 ```
 
-##### List Templates
+### List Templates
 
-```
+```json
 GET /_cat/templates?v&s=name
 ```
 
-##### List Indices
+### List Indices
 
-```
+```json
 GET /_cat/indices?v
 ```

--- a/infra/elasticsearch/iam.tf
+++ b/infra/elasticsearch/iam.tf
@@ -7,9 +7,8 @@ data "aws_iam_policy_document" "analytics_logging_role_policy" {
       "s3:ListBucketVersions",
     ]
 
-    effect = "Allow"
-
-    resources = ["${aws_s3_bucket.analytics_logging_bucket.arn}"]
+    effect    = "Allow"
+    resources = [aws_s3_bucket.analytics_logging_bucket.arn]
   }
 
   statement {
@@ -28,16 +27,16 @@ data "aws_iam_policy_document" "analytics_logging_role_policy" {
 }
 
 resource "aws_iam_policy" "analytics_logging_policy" {
-  policy = "${data.aws_iam_policy_document.analytics_logging_role_policy.json}"
-  name   = "${var.name}"
+  policy = data.aws_iam_policy_document.analytics_logging_role_policy.json
+  name   = var.name
 }
 
 resource "aws_iam_user_policy_attachment" "analytics_logging_user_policy_attachment" {
-  user       = "${aws_iam_user.analytics_logging_user.name}"
-  policy_arn = "${aws_iam_policy.analytics_logging_policy.arn}"
+  user       = aws_iam_user.analytics_logging_user.name
+  policy_arn = aws_iam_policy.analytics_logging_policy.arn
 }
 
 resource "aws_iam_user" "analytics_logging_user" {
-  name = "${var.name}"
+  name = var.name
   path = "/"
 }

--- a/infra/elasticsearch/provider.tf
+++ b/infra/elasticsearch/provider.tf
@@ -1,0 +1,14 @@
+terraform {
+  backend "s3" {
+    bucket     = "terraform.analytics.justice.gov.uk"
+    key        = "elasticsearch/terraform.tfstate"
+    region     = "eu-west-1"
+    encrypt    = true
+    kms_key_id = "arn:aws:kms:eu-west-1:593291632749:key/df8888e3-4080-4c2b-a71e-1425e72f98e4"
+  }
+}
+
+provider "aws" {
+  region  = "eu-west-1"
+  version = "~> 3"
+}

--- a/infra/elasticsearch/s3.tf
+++ b/infra/elasticsearch/s3.tf
@@ -1,15 +1,14 @@
 resource "aws_s3_bucket" "analytics_logging_bucket" {
-  bucket = "${var.name}"
+  bucket = var.name
   acl    = "private"
-  region = "${var.region}"
 
   versioning {
     enabled = true
   }
 
   server_side_encryption_configuration {
-    "rule" {
-      "apply_server_side_encryption_by_default" {
+    rule {
+      apply_server_side_encryption_by_default {
         sse_algorithm = "AES256"
       }
     }

--- a/infra/elasticsearch/terraform.tfvars.json
+++ b/infra/elasticsearch/terraform.tfvars.json
@@ -1,0 +1,3 @@
+{
+  "name": "analytics-logging-backups"
+}

--- a/infra/elasticsearch/variables.tf
+++ b/infra/elasticsearch/variables.tf
@@ -1,25 +1,3 @@
-terraform {
-  required_version = "~> 0.11.0"
-
-  backend "s3" {
-    bucket     = "terraform.analytics.justice.gov.uk"
-    key        = "elasticsearch/terraform.tfstate"
-    region     = "eu-west-1"
-    encrypt    = true
-    kms_key_id = "arn:aws:kms:eu-west-1:593291632749:key/df8888e3-4080-4c2b-a71e-1425e72f98e4"
-  }
-}
-
-provider "aws" {
-  region  = "${var.region}"
-  version = "~> 1.25.0"
-}
-
-variable "region" {
-  default = "eu-west-1"
-}
-
 variable "name" {
-  default     = "analytics-logging-backups"
   description = "The common name for the resources"
 }

--- a/infra/elasticsearch/versions.tf
+++ b/infra/elasticsearch/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+}


### PR DESCRIPTION
## What

Upgrade Elasticsearch Terraform to 0.13

This prepares for ElasticSearch module for moving it to the main Terraform

