### PR TITLE
Point bastion monitoring at new bastion lbs

### DIFF
--- a/infra/terraform/platform/main.tf
+++ b/infra/terraform/platform/main.tf
@@ -245,7 +245,7 @@ module "bastion_monitoring" {
   source = "./modules/elb_cloudwatch_alerts"
 
   name          = "${terraform.workspace}-bastion-alerts"
-  elb_name      = "bastion-${terraform.workspace}"
+  elb_name      = "${terraform.workspace}-bastion-lb"
   alarm_actions = [module.ap_infra_alert_topic.stack_notifications_arn]
 
   tags = merge(


### PR DESCRIPTION
Switch the bastion cloudwatch monitoring/alerts to point at the load balancer for the new bastions