### PR TITLE
Update bastion monitoring as we now use an NLB

### DIFF
--- a/infra/terraform/platform/data.tf
+++ b/infra/terraform/platform/data.tf
@@ -44,16 +44,24 @@ data "aws_route53_zone" "main" {
 
 
 data "aws_ami" "ubuntu" {
-    most_recent = true
+  most_recent = true
 
-    filter {
-        name   = "name"
-        values = ["ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*"]
-    }
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*"]
+  }
 
-    filter {
-        name   = "virtualization-type"
-        values = ["hvm"]
-    }
-    owners = ["099720109477"] # Canonical
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+  owners = ["099720109477"] # Canonical
+}
+
+data "aws_lb" "bastion" {
+  name = "${terraform.workspace}-bastion-lb"
+}
+
+data "aws_lb_target_group" "bastion" {
+  name = "${terraform.workspace}-bastion-lb-target"
 }


### PR DESCRIPTION
The old bastion monitoring was using ELB metrics. We are now using an NLB instead so we need to change the monitoring.

As it just requires one resource, I have defined the single resource rather than using/creating a module.

- Remove old bastion monitoring
- Add monitoring for number of healthy hosts in Bastion NLB target groups